### PR TITLE
Fix getUid2AdvertisingTokenWithRetry

### DIFF
--- a/src/integrationTests/secureSignal.test.ts
+++ b/src/integrationTests/secureSignal.test.ts
@@ -220,6 +220,14 @@ describe("when use script with SDK", () => {
 
 describe("getUid2AdvertisingTokenWithRetry", () => {
   test("should resolve with the result of the promise if it is successful", async () => {
+    const mockPromise = jest.fn(() => Promise.resolve("hello"));
+    const result = await getUid2AdvertisingTokenWithRetry(mockPromise);
+
+    expect(result).toEqual("hello");
+    expect(mockPromise).toHaveBeenCalledTimes(1);
+  });
+
+  test("should retry the request and resolve if the promise is successful", async () => {
     const mockPromise = jest.fn();
     mockPromise
       .mockReturnValueOnce(Promise.reject(new Error("Oops")))

--- a/src/integrationTests/secureSignal.test.ts
+++ b/src/integrationTests/secureSignal.test.ts
@@ -220,11 +220,14 @@ describe("when use script with SDK", () => {
 
 describe("getUid2AdvertisingTokenWithRetry", () => {
   test("should resolve with the result of the promise if it is successful", async () => {
-    const mockPromise = jest.fn(() => Promise.resolve("hello"));
+    const mockPromise = jest.fn();
+    mockPromise
+      .mockReturnValueOnce(Promise.reject(new Error("Oops")))
+      .mockReturnValueOnce(Promise.resolve("hello"));
     const result = await getUid2AdvertisingTokenWithRetry(mockPromise);
 
     expect(result).toEqual("hello");
-    expect(mockPromise).toHaveBeenCalledTimes(1);
+    expect(mockPromise).toHaveBeenCalledTimes(2);
   });
 
   test("should reject with the error if the promise is not successful after all retries", async () => {

--- a/src/secureSignal.ts
+++ b/src/secureSignal.ts
@@ -67,21 +67,22 @@ export function getUid2AdvertisingTokenWithRetry(
   return new Promise<string>(async (resolve, reject) => {
     let attempts = 0;
 
-    async function attempt() {
+    async function attempt(error?: unknown) {
+      if (attempts >= retries) {
+        reject(error);
+        return;
+      }
+
       attempts++;
-      return uid2Handler()
-        .then(resolve)
-        .catch((error: any) => {
-          if (attempts >= retries) {
-            reject(error);
-          } else {
-            attempt();
-          }
-        });
+
+      try {
+        const result = await uid2Handler();
+        resolve(result);
+      } catch (error) {
+        attempt(error);
+      }
     }
 
-    while (attempts < retries) {
-      await attempt();
-    }
+    attempt();
   });
 }


### PR DESCRIPTION
Fix the retry to be stoped calling itself as soon as uid2Handler resolved