### PR TITLE
Remove CSTG client version header

### DIFF
--- a/src/uid2ApiClient.ts
+++ b/src/uid2ApiClient.ts
@@ -256,7 +256,6 @@ export class Uid2ApiClient {
     this._requestsInFlight.push(req);
     req.overrideMimeType("text/plain");
     req.open("POST", url, true);
-    req.setRequestHeader("X-UID2-Client-Version", this._clientVersion);
 
     let resolvePromise: (result: CstgResult) => void;
     let rejectPromise: (reason: unknown) => void;


### PR DESCRIPTION
This header is causing the CSTG request to be preflighted. We will add the version back at a later date, in a way that doesn't have this problem.