### PR TITLE
Add debug mode to secure signal script

### DIFF
--- a/examples/google-esp-integration/server_only/views/header.html
+++ b/examples/google-esp-integration/server_only/views/header.html
@@ -16,26 +16,11 @@
     ></script>
 
     <script type="text/javascript">
-      const getCookie = (cname) => {
-        let name = cname + "=";
-        let ca = document.cookie.split(";");
-        for (let i = 0; i < ca.length; i++) {
-          let c = ca[i];
-          while (c.charAt(0) == " ") {
-            c = c.substring(1);
-          }
-          if (c.indexOf(name) == 0) {
-            return c.substring(name.length, c.length);
-          }
-        }
-        return "";
-      };
-
       const getUid2AdvertisingToken = async () => {
-        await fetch("/getFreshToken").then((res) => res.json());
-        const uid2Token = getCookie("identity");
-        if (uid2Token === "") return;
-        return JSON.parse(decodeURIComponent(uid2Token)).advertising_token;
+        const response = await fetch("/getFreshToken");
+        const result = await response.json();
+        console.log(result);
+        return result.advertising_token;
       };
 
       window.getUid2AdvertisingToken = getUid2AdvertisingToken;

--- a/src/integrationTests/secureSignal.test.ts
+++ b/src/integrationTests/secureSignal.test.ts
@@ -76,7 +76,7 @@ describe("Secure Signal Tests", () => {
           uid2ESP.registerSecureSignalProvider();
           expect(console.warn).toHaveBeenCalledTimes(1);
           expect(consoleWarnMock).toHaveBeenCalledWith(
-            "Please implement `getUid2AdvertisingToken`"
+            "Uid2SecureSignal: Please implement `getUid2AdvertisingToken`"
           );
           expect(secureSignalProvidersPushMock).not.toBeCalled();
         });

--- a/src/secureSignal.ts
+++ b/src/secureSignal.ts
@@ -1,5 +1,5 @@
 const MAXIMUM_RETRY = 3;
-const INTEG_BASE_URL = "http://localhost:3000/";
+const INTEG_BASE_URL = "https://cdn.integ.uidapi.com/";
 export class Uid2SecureSignalProvider {
   debug: boolean;
   constructor(debug = false) {


### PR DESCRIPTION
- Add debug mode for user who have `uid2_ss_debug`  in their query string (e.g. single app user) or who use script hosted in integ
- Simplified the server-only example