### PR TITLE
ajy-UID2-1667-ESP-example-site-vscode-task

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,6 +16,19 @@
       "sourceMapPathOverrides": {
         "webpack://@uid2/uid2-sdk/./*": "${webRoot}/*"
       }
+    },
+    {
+      "name": "Launch ESP (Chrome)",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:9090",
+      "webRoot": "${workspaceRoot}/",
+      "sourceMaps": true,
+      "preLaunchTask": "Start ESP",
+      "postDebugTask": "Terminate ESP",
+      "sourceMapPathOverrides": {
+        "webpack://@uid2/uid2-sdk/./*": "${webRoot}/*"
+      }
     }
   ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -93,12 +93,7 @@
             "permissions": "ro"
           }
         ],
-        "env": {
-          "UID2_BASE_URL": "http://localhost:8080",
-          "UID2_JS_SDK_URL": "http://localhost:9091/uid2-sdk.js",
-          "SERVER_PUBLIC_KEY": "UID2-X-I-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtXJdTSZAYHvoRDWiehMHoWF1BNPuqLs5w2ZHiAZ1IJc7O4/z0ojPTB0V+KYX/wxQK0hxx6kxCvHj335eI/ZQsQ==",
-          "SUBSCRIPTION_ID": "4WvryDGbR5"
-        },
+        "envFile": "${workspaceFolder}/examples/google-esp-integration/with_sdk_v3/.env",
         "remove": true
       }
     },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -88,13 +88,13 @@
         ],
         "volumes": [
           {
-            "localPath": "${workspaceFolder}/examples/google-esp-integration/with_sdk_v3",
-            "containerPath": "/usr/share/nginx/html",
+            "localPath": "${workspaceFolder}/examples/google-esp-integration/with_sdk_v3/views",
+            "containerPath": "/usr/src/app/views",
             "permissions": "ro"
           }
         ],
-        "envFile": "${workspaceFolder}/examples/google-esp-integration/with_sdk_v3/.env",
-        "remove": true
+        "envFiles": ["${workspaceFolder}/examples/google-esp-integration/with_sdk_v3/.env"],
+        "remove": true,
       }
     },
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -83,13 +83,13 @@
         "ports": [
           {
             "hostPort": 9090,
-            "containerPort": 80
+            "containerPort": 3000
           }
         ],
         "volumes": [
           {
-            "localPath": "${workspaceFolder}/examples/google-esp-integration/with_sdk_v3", // unsure of this, maybe needs `views` in the path
-            "containerPath": "/usr/share/nginx/html", // unsure
+            "localPath": "${workspaceFolder}/examples/google-esp-integration/with_sdk_v3",
+            "containerPath": "/usr/share/nginx/html",
             "permissions": "ro"
           }
         ],

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -37,6 +37,14 @@
       }
     },
     {
+      "label": "Build ESP Image",
+      "type": "docker-build",
+      "dockerBuild": {
+        "context": "${workspaceFolder}/examples/google-esp-integration/with_sdk_v3",
+        "tag": "uid2-esp-example"
+      }
+    },
+    {
       "label": "Run CSTG Container",
       "type": "docker-run",
       "dependsOn": ["Build CSTG Image"],
@@ -66,13 +74,50 @@
       }
     },
     {
+      "label": "Run ESP Container",
+      "type": "docker-run",
+      "dependsOn": ["Build ESP Image"],
+      "dockerRun": {
+        "image": "uid2-esp-example",
+        "containerName": "uid2-esp-example",
+        "ports": [
+          {
+            "hostPort": 9090,
+            "containerPort": 80
+          }
+        ],
+        "volumes": [
+          {
+            "localPath": "${workspaceFolder}/examples/google-esp-integration/with_sdk_v3", // unsure of this, maybe needs `views` in the path
+            "containerPath": "/usr/share/nginx/html", // unsure
+            "permissions": "ro"
+          }
+        ],
+        "env": {
+          "UID2_BASE_URL": "http://localhost:8080",
+          "UID2_JS_SDK_URL": "http://localhost:9091/uid2-sdk.js",
+          "SERVER_PUBLIC_KEY": "UID2-X-I-MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtXJdTSZAYHvoRDWiehMHoWF1BNPuqLs5w2ZHiAZ1IJc7O4/z0ojPTB0V+KYX/wxQK0hxx6kxCvHj335eI/ZQsQ==",
+          "SUBSCRIPTION_ID": "4WvryDGbR5"
+        },
+        "remove": true
+      }
+    },
+    {
       "label": "Start CSTG",
       "dependsOn": ["webpack-dev-server", "Run CSTG Container"]
+    },    {
+      "label": "Start ESP",
+      "dependsOn": ["webpack-dev-server", "Run ESP Container"]
     },
     {
       "label": "Terminate CSTG Container",
       "type": "shell",
       "command": "docker stop uid2-cstg-example"
+    },
+    {
+      "label": "Terminate ESP Container",
+      "type": "shell",
+      "command": "docker stop uid2-esp-example"
     },
     {
       "label": "Terminate All Tasks",
@@ -83,6 +128,10 @@
     {
       "label": "Terminate CSTG",
       "dependsOn": ["Terminate All Tasks", "Terminate CSTG Container"]
+    },
+    {
+      "label": "Terminate ESP",
+      "dependsOn": ["Terminate All Tasks", "Terminate ESP Container"]
     }
   ],
   "inputs": [

--- a/examples/google-esp-integration/with_sdk_v3/.env
+++ b/examples/google-esp-integration/with_sdk_v3/.env
@@ -1,4 +1,0 @@
-UID2_BASE_URL="http://localhost:8080"
-UID2_JS_SDK_URL="http://localhost:9091/uid2-sdk.js"
-UID2_API_KEY="<your-integ-API-key>"
-UID2_CLIENT_SECRET="<your-integ-client-secret>"

--- a/examples/google-esp-integration/with_sdk_v3/.env
+++ b/examples/google-esp-integration/with_sdk_v3/.env
@@ -1,0 +1,4 @@
+UID2_BASE_URL="http://localhost:8080"
+UID2_JS_SDK_URL="http://localhost:9091/uid2-sdk.js"
+UID2_API_KEY="<your-integ-API-key>"
+UID2_CLIENT_SECRET="<your-integ-client-secret>"

--- a/examples/google-esp-integration/with_sdk_v3/.gitignore
+++ b/examples/google-esp-integration/with_sdk_v3/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.env

--- a/examples/google-esp-integration/with_sdk_v3/README.md
+++ b/examples/google-esp-integration/with_sdk_v3/README.md
@@ -12,6 +12,7 @@ For an example application without using the UID2 SDK, see [Server-Only UID2 Int
 
 The easiest way to try the example is to do the following:
 1. Open this repo in VS Code
+1. Populate `UID2_API_KEY` and `UID2_CLIENT_SECRET` in your `.env` file.
 1. Click the Run and Debug tab or hit `Crtl+Shift+D`
 1. Select `Launch ESP (Chrome)` from the configuration dropdown
 1. Click `Start Debugging` or hit F5

--- a/examples/google-esp-integration/with_sdk_v3/README.md
+++ b/examples/google-esp-integration/with_sdk_v3/README.md
@@ -26,16 +26,16 @@ The easiest way to try the example is to do the following:
 
 ### Running the Docker commands manually
 
-The other way to try the example is to use the following Docker Build command:
+The other way to try the example is to use the following Docker Build command. First, open this folder in your terminal, then run the following:
 
 ```
 docker build . -t uid2-esp-standard
-docker run -it --rm -p 3000:3000 \
-    -e UID2_BASE_URL="https://operator-integ.uidapi.com" \
-    -e UID2_API_KEY="<your-integ-API-key>" \
-    -e UID2_CLIENT_SECRET="<your-integ-client-secret>" \
-    -e AD_TAG_URL="https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/extrernal/adx-test-tag&tfcd=0&npa=0&sz=640x480&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=" \
-    -e UID2_JS_SDK_URL="<your-JS-SDK-URL>" \
+docker run -it --rm -p 3000:3000 `
+    -e UID2_BASE_URL="https://operator-integ.uidapi.com" `
+    -e UID2_API_KEY="<your-integ-API-key>" `
+    -e UID2_CLIENT_SECRET="<your-integ-client-secret>" `
+    -e AD_TAG_URL="https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/extrernal/adx-test-tag&tfcd=0&npa=0&sz=640x480&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=" `
+    -e UID2_JS_SDK_URL="<your-JS-SDK-URL>" `
     uid2-esp-standard
 ```
 

--- a/examples/google-esp-integration/with_sdk_v3/README.md
+++ b/examples/google-esp-integration/with_sdk_v3/README.md
@@ -8,7 +8,17 @@ For an example application without using the UID2 SDK, see [Server-Only UID2 Int
 
 ## Build and Run the Example Application
 
-The easiest way to try the example is to use the following Docker Build command:
+### Using the VS Code Debugger
+
+The easiest way to try the example is to do the following:
+1. Open this repo in VS Code
+1. Click the Run and Debug tab or hit `Crtl+Shift+D`
+1. Select `Launch ESP (Chrome)` from the configuration dropdown
+1. Click `Start Debugging` or hit F5
+
+### Running the Docker commands manually
+
+The other way to try the example is to use the following Docker Build command:
 
 ```
 docker build . -t uid2-esp-standard
@@ -17,6 +27,7 @@ docker run -it --rm -p 3000:3000 \
     -e UID2_API_KEY="<your-integ-API-key>" \
     -e UID2_CLIENT_SECRET="<your-integ-client-secret>" \
     -e AD_TAG_URL="<your-IMA-ad-tag-url>" \
+    -e UID2_JS_SDK_URL="<your-JS-SDK-URL>" \
     uid2-esp-standard
 ```
 
@@ -28,6 +39,7 @@ The following table lists the environment variables that you must specify to sta
 | `UID2_API_KEY`       | string    | Your UID2 authentication key for the UID2 service specified in `UID2_BASE_URL`.                                                                          |
 | `UID2_CLIENT_SECRET` | string    | Your UID2 client secret for the UID2 service specified in `UID2_BASE_URL`.                                                                               |
 | `AD_TAG_URL`         | string    | The ad tag URL to test ad requests.                                                                                                                      |
+| `UID2_JS_SDK_URL`    | string    | The UID2 JS SDK. If this optional parameter it not provided, it will default to the integ URL specified in `server.js`                                                                                                                      |
 
 Output similar to the following indicates that the example application is up and running.
 

--- a/examples/google-esp-integration/with_sdk_v3/README.md
+++ b/examples/google-esp-integration/with_sdk_v3/README.md
@@ -12,7 +12,13 @@ For an example application without using the UID2 SDK, see [Server-Only UID2 Int
 
 The easiest way to try the example is to do the following:
 1. Open this repo in VS Code
-1. Populate `UID2_API_KEY` and `UID2_CLIENT_SECRET` in your `.env` file.
+1. Create a `.env` file in this folder and populate `UID2_API_KEY` and `UID2_CLIENT_SECRET`:
+    ```
+    UID2_BASE_URL="http://localhost:8080"
+    UID2_JS_SDK_URL="http://localhost:9091/uid2-sdk.js"
+    UID2_API_KEY="<your-integ-API-key>"
+    UID2_CLIENT_SECRET="<your-integ-client-secret>"
+    ```
 1. Click the Run and Debug tab or hit `Crtl+Shift+D`
 1. Select `Launch ESP (Chrome)` from the configuration dropdown
 1. Click `Start Debugging` or hit F5
@@ -40,7 +46,7 @@ The following table lists the environment variables that you must specify to sta
 | `UID2_API_KEY`       | string    | Your UID2 authentication key for the UID2 service specified in `UID2_BASE_URL`.                                                                          |
 | `UID2_CLIENT_SECRET` | string    | Your UID2 client secret for the UID2 service specified in `UID2_BASE_URL`.                                                                               |
 | `AD_TAG_URL`         | string    | The ad tag URL to test ad requests.                                                                                                                      |
-| `UID2_JS_SDK_URL`    | string    | The UID2 JS SDK. If this optional parameter it not provided, it will default to the integ URL specified in `server.js`                                                                                                                      |
+| `UID2_JS_SDK_URL`    | string    | The UID2 JS SDK. If this optional parameter it not provided, it will default to the integ URL specified in `server.js`                                   |
 
 Output similar to the following indicates that the example application is up and running.
 

--- a/examples/google-esp-integration/with_sdk_v3/README.md
+++ b/examples/google-esp-integration/with_sdk_v3/README.md
@@ -14,10 +14,11 @@ The easiest way to try the example is to do the following:
 1. Open this repo in VS Code
 1. Create a `.env` file in this folder and populate `UID2_API_KEY` and `UID2_CLIENT_SECRET`:
     ```
-    UID2_BASE_URL="http://localhost:8080"
-    UID2_JS_SDK_URL="http://localhost:9091/uid2-sdk.js"
-    UID2_API_KEY="<your-integ-API-key>"
-    UID2_CLIENT_SECRET="<your-integ-client-secret>"
+    UID2_BASE_URL=http://localhost:8080
+    UID2_API_KEY=<your-integ-API-key>
+    UID2_CLIENT_SECRET=<your-integ-client-secret>
+    AD_TAG_URL=https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/extrernal/adx-test-tag&tfcd=0&npa=0&sz=640x480&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=
+    UID2_JS_SDK_URL=http://localhost:9091/uid2-sdk.js
     ```
 1. Click the Run and Debug tab or hit `Crtl+Shift+D`
 1. Select `Launch ESP (Chrome)` from the configuration dropdown
@@ -33,7 +34,7 @@ docker run -it --rm -p 3000:3000 \
     -e UID2_BASE_URL="https://operator-integ.uidapi.com" \
     -e UID2_API_KEY="<your-integ-API-key>" \
     -e UID2_CLIENT_SECRET="<your-integ-client-secret>" \
-    -e AD_TAG_URL="<your-IMA-ad-tag-url>" \
+    -e AD_TAG_URL="https://pubads.g.doubleclick.net/gampad/ads?iu=/21775744923/extrernal/adx-test-tag&tfcd=0&npa=0&sz=640x480&gdfp_req=1&output=vast&unviewed_position_start=1&env=vp&impl=s&correlator=" \
     -e UID2_JS_SDK_URL="<your-JS-SDK-URL>" \
     uid2-esp-standard
 ```

--- a/examples/google-esp-integration/with_sdk_v3/server.js
+++ b/examples/google-esp-integration/with_sdk_v3/server.js
@@ -157,6 +157,7 @@ app.post("/login", async (req, res) => {
       res.render("login", {
         identity: response.body,
         uid2BaseUrl: uid2BaseUrl,
+        uid2JsSdkUrl: uid2JsSdkUrl,
       });
     }
   } catch (error) {

--- a/examples/google-esp-integration/with_sdk_v3/server.js
+++ b/examples/google-esp-integration/with_sdk_v3/server.js
@@ -9,7 +9,7 @@ const port = process.env.PORT || 3000;
 const uid2BaseUrl = process.env.UID2_BASE_URL;
 const uid2ApiKey = process.env.UID2_API_KEY;
 const uid2ClientSecret = process.env.UID2_CLIENT_SECRET;
-const uid2JsSdkUrl = process.env.UID2_JS_SDK_URL;
+const uid2JsSdkUrl = process.env.UID2_JS_SDK_URL || "https://cdn.integ.uidapi.com/uid2-sdk-3.0.1.js";
 
 const ivLength = 12;
 const nonceLength = 8;

--- a/examples/google-esp-integration/with_sdk_v3/server.js
+++ b/examples/google-esp-integration/with_sdk_v3/server.js
@@ -9,6 +9,7 @@ const port = process.env.PORT || 3000;
 const uid2BaseUrl = process.env.UID2_BASE_URL;
 const uid2ApiKey = process.env.UID2_API_KEY;
 const uid2ClientSecret = process.env.UID2_CLIENT_SECRET;
+const uid2JsSdkUrl = process.env.UID2_JS_SDK_URL;
 
 const ivLength = 12;
 const nonceLength = 8;
@@ -22,7 +23,7 @@ app.engine(".html", ejs.__express);
 app.set("view engine", "html");
 
 app.get("/", (req, res) => {
-  res.render("index", { uid2BaseUrl: uid2BaseUrl });
+  res.render("index", { uid2BaseUrl: uid2BaseUrl, uid2JsSdkUrl: uid2JsSdkUrl });
 });
 
 function bufferToBase64(arrayBuffer) {

--- a/examples/google-esp-integration/with_sdk_v3/views/index.html
+++ b/examples/google-esp-integration/with_sdk_v3/views/index.html
@@ -77,7 +77,7 @@
       <button id="playButton">Play</button>
       <script type="text/javascript" src="//imasdk.googleapis.com/js/sdkloader/ima3.js"></script>
       <script async src="https://cdn.integ.uidapi.com/uid2SecureSignal.js"></script>
-      <script async src="https://cdn.integ.uidapi.com/uid2-sdk-3.0.1.js"></script>
+      <script async src="<%- uid2JsSdkUrl %>"></script>
       <script async src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"></script>
       <script type="text/javascript" src="ads.js"></script>
     </div>

--- a/examples/google-esp-integration/with_sdk_v3/views/login.html
+++ b/examples/google-esp-integration/with_sdk_v3/views/login.html
@@ -9,7 +9,7 @@
       async
       src="https://cdn.integ.uidapi.com/uid2SecureSignal.js"
     ></script>
-    <script async src="https://cdn.integ.uidapi.com/uid2-sdk-3.0.1.js"></script>
+    <script async src="<%- uid2JsSdkUrl %>"></script>
     <script
       async
       src="https://securepubads.g.doubleclick.net/tag/js/gpt.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@uid2/uid2-sdk",
-      "version": "3.0.3",
+      "version": "3.1.0a0",
       "license": "Apache 2.0",
       "devDependencies": {
         "@jest/globals": "^29.2.2",


### PR DESCRIPTION
- Create vscode Launch ESP launch and associated tasks
- Update `with_sdk_v3` views to use the provided UID2 JS SDK URL rather than just the integ one.
- Update README to explain how to use this vscode launch config

## Manual testing

**Example site pointing to local JS SDK, allowing for debugging, etc.**
 
https://github.com/IABTechLab/uid2-web-integrations/assets/137864392/0f636947-e267-40d1-aad4-6a987740df26

**HMR for html views on refresh**

https://github.com/IABTechLab/uid2-web-integrations/assets/137864392/7dbd9bf5-f043-48f1-84c5-376cd5d35679

### When pointing to integ

**Logging in works**

https://github.com/IABTechLab/uid2-web-integrations/assets/137864392/12b8a375-c7cc-4dba-893e-f37dfa51ebaa




