### PR TITLE
Add support for optouts to refresh and CSTG calls.

### DIFF
--- a/src/Uid2Identity.ts
+++ b/src/Uid2Identity.ts
@@ -25,3 +25,14 @@ export function isValidIdentity(identity: Uid2Identity | unknown): identity is U
     'refresh_expires' in identity
   );
 }
+export interface OptoutIdentity extends Pick<Uid2Identity, 'refresh_expires' | 'identity_expires'> {
+  status: 'optout';
+}
+export function isOptoutIdentity(identity: OptoutIdentity | unknown): identity is OptoutIdentity {
+  return (
+    typeof identity === 'object' &&
+    identity !== null &&
+    'status' in identity &&
+    identity.status === 'optout'
+  );
+}

--- a/src/Uid2Identity.ts
+++ b/src/Uid2Identity.ts
@@ -29,10 +29,7 @@ export interface OptoutIdentity extends Pick<Uid2Identity, 'refresh_expires' | '
   status: 'optout';
 }
 export function isOptoutIdentity(identity: OptoutIdentity | unknown): identity is OptoutIdentity {
-  return (
-    typeof identity === 'object' &&
-    identity !== null &&
-    'status' in identity &&
-    identity.status === 'optout'
-  );
+  if (identity === null || typeof identity !== 'object') return false;
+  const maybeIdentity = identity as OptoutIdentity;
+  return maybeIdentity.status === 'optout';
 }

--- a/src/integrationTests/autoRefresh.test.ts
+++ b/src/integrationTests/autoRefresh.test.ts
@@ -172,7 +172,7 @@ testCookieAndLocalStorage(() => {
         }
       });
       test('getAdvertisingTokenPromise should reject', () => {
-        expect(exception).toEqual(new Error('UID2 SDK aborted.'));
+        expect(exception).toEqual(new Error('No identity available.'));
       });
       test('should invoke the callback', () => {
         expect(callback).toHaveBeenNthCalledWith(
@@ -185,7 +185,7 @@ testCookieAndLocalStorage(() => {
         );
       });
       test('should clear value', () => {
-        expect(getUid2(useCookie)).toBeNull();
+        expect(getUid2(useCookie)).toMatchObject({ status: 'optout' });
       });
       test('should not set refresh timer', () => {
         expect(setTimeout).not.toHaveBeenCalled();
@@ -425,7 +425,7 @@ testCookieAndLocalStorage(() => {
         }
       });
       test('getAdvertisingTokenPromise should reject', () => {
-        expect(exception).toEqual(new Error('UID2 SDK aborted.'));
+        expect(exception).toEqual(new Error('No identity available.'));
       });
       test('should invoke the callback', () => {
         expect(callback).toHaveBeenNthCalledWith(
@@ -437,8 +437,8 @@ testCookieAndLocalStorage(() => {
           })
         );
       });
-      test('should clear value', () => {
-        expect(getUid2(useCookie)).toBeNull();
+      test('should store optout', () => {
+        expect(getUid2(useCookie)).toMatchObject({ status: 'optout' });
       });
       test('should not set refresh timer', () => {
         expect(setTimeout).not.toHaveBeenCalled();

--- a/src/uid2CallbackManager.ts
+++ b/src/uid2CallbackManager.ts
@@ -1,11 +1,12 @@
 import { UID2SdkBase } from './sdkBase';
-import { Uid2Identity } from './Uid2Identity';
+import { OptoutIdentity, Uid2Identity } from './Uid2Identity';
 import { Logger } from './sdk/logger';
 
 export enum EventType {
   InitCompleted = 'InitCompleted',
   IdentityUpdated = 'IdentityUpdated',
   SdkLoaded = 'SdkLoaded',
+  OptoutReceived = 'OptoutReceived',
 }
 
 export type Uid2CallbackPayload = SdkLoadedPayload | PayloadWithIdentity;
@@ -24,7 +25,7 @@ export class Uid2CallbackManager {
   constructor(
     sdk: UID2SdkBase,
     productName: string,
-    getIdentity: () => Uid2Identity | null | undefined,
+    getIdentity: () => Uid2Identity | OptoutIdentity | null | undefined,
     logger: Logger
   ) {
     this._productName = productName;

--- a/src/uid2CallbackManager.ts
+++ b/src/uid2CallbackManager.ts
@@ -1,5 +1,5 @@
 import { UID2SdkBase } from './sdkBase';
-import { OptoutIdentity, Uid2Identity } from './Uid2Identity';
+import { Uid2Identity } from './Uid2Identity';
 import { Logger } from './sdk/logger';
 
 export enum EventType {
@@ -25,7 +25,7 @@ export class Uid2CallbackManager {
   constructor(
     sdk: UID2SdkBase,
     productName: string,
-    getIdentity: () => Uid2Identity | OptoutIdentity | null | undefined,
+    getIdentity: () => Uid2Identity | null | undefined,
     logger: Logger
   ) {
     this._productName = productName;

--- a/src/uid2CookieManager.ts
+++ b/src/uid2CookieManager.ts
@@ -1,4 +1,4 @@
-import { isValidIdentity, Uid2Identity } from './Uid2Identity';
+import { isValidIdentity, Uid2Identity, OptoutIdentity, isOptoutIdentity } from './Uid2Identity';
 
 export type UID2CookieOptions = {
   cookieDomain?: string;
@@ -38,7 +38,7 @@ export class UID2CookieManager {
     this._cookieName = cookieName;
     this._opts = opts;
   }
-  public setCookie(identity: Uid2Identity) {
+  public setCookie(identity: Uid2Identity | OptoutIdentity) {
     const value = JSON.stringify(identity);
     const expires = new Date(identity.refresh_expires);
     const path = this._opts.cookiePath ?? '/';
@@ -74,11 +74,12 @@ export class UID2CookieManager {
     return newCookie;
   }
 
-  public loadIdentityFromCookie(): Uid2Identity | null {
+  public loadIdentityFromCookie(): Uid2Identity | OptoutIdentity | null {
     const payload = this.getCookie();
     if (payload) {
       const result = JSON.parse(payload) as unknown;
       if (isValidIdentity(result)) return result;
+      if (isOptoutIdentity(result)) return result;
       if (isLegacyCookie(result)) {
         return this.migrateLegacyCookie(result, Date.now());
       }

--- a/src/uid2LocalStorageManager.ts
+++ b/src/uid2LocalStorageManager.ts
@@ -1,11 +1,11 @@
-import { isValidIdentity, Uid2Identity } from './Uid2Identity';
+import { isOptoutIdentity, isValidIdentity, OptoutIdentity, Uid2Identity } from './Uid2Identity';
 
 export class UID2LocalStorageManager {
   private _storageKey: string;
   constructor(storageKey: string) {
     this._storageKey = storageKey;
   }
-  public setValue(identity: Uid2Identity) {
+  public setValue(identity: Uid2Identity | OptoutIdentity) {
     const value = JSON.stringify(identity);
     localStorage.setItem(this._storageKey, value);
   }
@@ -16,11 +16,12 @@ export class UID2LocalStorageManager {
     return localStorage.getItem(this._storageKey);
   }
 
-  public loadIdentityFromLocalStorage(): Uid2Identity | null {
+  public loadIdentityFromLocalStorage(): Uid2Identity | OptoutIdentity | null {
     const payload = this.getValue();
     if (payload) {
       const result = JSON.parse(payload) as unknown;
       if (isValidIdentity(result)) return result;
+      if (isOptoutIdentity(result)) return result;
     }
     return null;
   }

--- a/src/unitTests/uid2ApiClient.test.ts
+++ b/src/unitTests/uid2ApiClient.test.ts
@@ -1,7 +1,8 @@
 import { NAME_CURVE, XhrMock, makeCstgOption, makeIdentityV2 } from '../mocks';
-import { Uid2ApiClient } from '../uid2ApiClient';
+import { SuccessCstgResult, Uid2ApiClient } from '../uid2ApiClient';
 import { base64ToBytes, bytesToBase64 } from '../encoding/uid2Base64';
 import { sdkWindow } from '../uid2Sdk';
+import { Uid2Identity } from '../Uid2Identity';
 
 describe('UID2 API client tests', () => {
   let uid2ApiClient: Uid2ApiClient;
@@ -50,7 +51,7 @@ describe('UID2 API client tests', () => {
           );
         });
 
-        const cstgResult = await makeCstgApiCall();
+        const cstgResult = (await makeCstgApiCall()) as SuccessCstgResult;
         expect(cstgResult.identity).toEqual(uid2Token);
       });
 


### PR DESCRIPTION
If an optout is received, an additional new OptoutReceived event will be triggered. There's a new hasOptedOut public function that returns a bool.