### PR TITLE
UID2-3221 Removed redundant optout_check flag in CSTG calls altogether

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -216,11 +216,8 @@ export class ApiClient {
     data: { emailHash: string } | { phoneHash: string },
     opts: ClientSideIdentityOptions
   ): Promise<CstgResult> {
-    const optoutPayload = this._productName == 'EUID' ? { optout_check: 1 } : {};
     const request =
-      'emailHash' in data
-        ? { email_hash: data.emailHash, ...optoutPayload }
-        : { phone_hash: data.phoneHash, ...optoutPayload };
+        'emailHash' in data ? { email_hash: data.emailHash } : { phone_hash: data.phoneHash };
 
     const box = await CstgBox.build(stripPublicKeyPrefix(opts.serverPublicKey));
 


### PR DESCRIPTION
As titled as we are removing the CSTG optout_check flag processing in backend operator in:
https://github.com/IABTechLab/uid2-operator/pull/830
https://atlassian.thetradedesk.com/jira/browse/UID2-2904
