### PR TITLE
UID2-2904 CSTG Optout Handling fix 

### DIFF
--- a/setupJest.js
+++ b/setupJest.js
@@ -51,11 +51,24 @@ expect.extend({
   toBeInUnavailableState(uid2) {
     expect(uid2.getAdvertisingToken()).toBeUndefined();
     expect(uid2.isLoginRequired()).toEqual(true);
+    expect(uid2.hasOptedOut()).toEqual(false);
 
     return {
       pass: true,
       message: () =>
         'Expected getAdvertisingToken() returns undefined and isLoginRequired() returns true',
+    };
+  },
+
+  toBeInOptoutState(uid2) {
+    expect(uid2.getAdvertisingToken()).toBeUndefined();
+    expect(uid2.isLoginRequired()).toEqual(false);
+    expect(uid2.hasOptedOut()).toEqual(true);
+
+    return {
+      pass: true,
+      message: () =>
+          'Expected getAdvertisingToken() returns undefined and isLoginRequired() returns false',
     };
   },
 });

--- a/src/integrationTests/autoRefresh.test.ts
+++ b/src/integrationTests/autoRefresh.test.ts
@@ -191,8 +191,8 @@ testCookieAndLocalStorage(() => {
         expect(setTimeout).not.toHaveBeenCalled();
         expect(clearTimeout).not.toHaveBeenCalled();
       });
-      test('should be in unavailable state', () => {
-        (expect(uid2) as any).toBeInUnavailableState();
+      test('should be in optout state', () => {
+        (expect(uid2) as any).toBeInOptoutState();
       });
     });
 
@@ -444,8 +444,8 @@ testCookieAndLocalStorage(() => {
         expect(setTimeout).not.toHaveBeenCalled();
         expect(clearTimeout).not.toHaveBeenCalled();
       });
-      test('should be in unavailable state', () => {
-        (expect(uid2) as any).toBeInUnavailableState();
+      test('should be in optout state', () => {
+        (expect(uid2) as any).toBeInOptoutState();
       });
     });
 

--- a/src/integrationTests/basic.test.ts
+++ b/src/integrationTests/basic.test.ts
@@ -562,8 +562,8 @@ testCookieAndLocalStorage(() => {
         expect(setTimeout).not.toHaveBeenCalled();
         expect(clearTimeout).not.toHaveBeenCalled();
       });
-      test('should be in unavailable state', () => {
-        (expect(uid2) as any).toBeInUnavailableState();
+      test('should be in optout state', () => {
+        (expect(uid2) as any).toBeInOptoutState();
       });
     });
 
@@ -825,8 +825,8 @@ testCookieAndLocalStorage(() => {
         expect(setTimeout).not.toHaveBeenCalled();
         expect(clearTimeout).not.toHaveBeenCalled();
       });
-      test('should be in unavailable state', () => {
-        (expect(uid2) as any).toBeInUnavailableState();
+      test('should be in optout state', () => {
+        (expect(uid2) as any).toBeInOptoutState();
       });
     });
 

--- a/src/integrationTests/clientSideTokenGeneration.test.ts
+++ b/src/integrationTests/clientSideTokenGeneration.test.ts
@@ -178,9 +178,9 @@ describe('Client-side token generation Tests', () => {
               );
             });
           });
-          test('UID2 should not be available', async () => {
+          test('UID2 should be in optout state', async () => {
             await scenario.setIdentity(serverPublicKey);
-            (expect(uid2) as any).toBeInUnavailableState();
+            (expect(uid2) as any).toBeInOptoutState();
           });
 
           test('The callback should be called with no identity', (done) => {

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -308,7 +308,6 @@ export abstract class SdkBase {
     )
       return validity.identity;
 
-    this._identity = validity.identity;
     if (validity.valid && validity.identity) {
       this._storageManager.setIdentity(validity.identity);
     } else if (validity.status === IdentityStatus.OPTOUT || status === IdentityStatus.OPTOUT) {
@@ -317,6 +316,7 @@ export abstract class SdkBase {
       this.abort();
       this._storageManager.removeValues();
     }
+    this._identity = this._storageManager.loadIdentity();
     notifyInitCallback(
       this._opts,
       status ?? validity.status,


### PR DESCRIPTION
1. set ```this._identity``` to an optout identity instead of null so that after, receiving a CSTG optout response, hasOptedOut() and isLoginRequired() should return true/false respectively. Without the fix, they return false/true and this could cause pub to repeatedly call setIdentityFromXXX calls which will never return a legit token since the DII has opted out

2. Without this fix, after a CSTG call is done and optout response is received, and THEN a page reload, hasOptedOut() and isLoginRequired() alreadys return true/false respectively. So this fix only applies to optout handling straight after the CSTG response is received before page reload.