### PR TITLE
Ans UI d2 3834 allow js sdk accept multiple init calls

### DIFF
--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -127,6 +127,10 @@ export class ApiClient {
     return this._requestsInFlight.length > 0;
   }
 
+  public updateBaseUrl(newBaseUrl: string) {
+    this._baseUrl = newBaseUrl;
+  }
+
   private ResponseToRefreshResult(
     response: UnvalidatedRefreshResponse | unknown
   ): RefreshResult | string {

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -47,7 +47,7 @@ export const updateConfig = (
 
 export const removeConfig = (previousOptions: SdkOptions, productDetails: ProductDetails) => {
   if (previousOptions.useCookie) {
-    removeConfigCookie(productDetails, previousOptions);
+    removeConfigCookie(previousOptions, productDetails);
   } else {
     removeConfigFromLocalStorage(productDetails);
   }
@@ -65,7 +65,7 @@ const setConfigCookie = (options: SdkOptions, productDetails: ProductDetails) =>
   document.cookie = cookie;
 };
 
-const removeConfigCookie = (productDetails: ProductDetails, previousOptions: SdkOptions) => {
+const removeConfigCookie = (previousOptions: SdkOptions, productDetails: ProductDetails) => {
   document.cookie =
     productDetails.cookieName +
     '_config' +

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -36,16 +36,21 @@ export const loadConfig = (
   }
 };
 
-export const updateConfig = (options: SdkOptions, productDetails: ProductDetails) => {
+export const updateConfig = (
+  options: SdkOptions,
+  productDetails: ProductDetails,
+  previousCookieDomain: string | undefined,
+  previousCookiePath: string | undefined
+) => {
   if (options.useCookie) {
-    removeConfigCookie(productDetails);
+    removeConfigCookie(options, productDetails, previousCookieDomain, previousCookiePath);
   } else {
     removeConfigFromLocalStorage(productDetails);
   }
   storeConfig(options, productDetails);
 };
 
-const setConfigCookie = (options: SdkOptions, productDetails: ProductDetails) => {
+export const setConfigCookie = (options: SdkOptions, productDetails: ProductDetails) => {
   const cookieDomain = options.cookieDomain;
   const path = options.cookiePath ?? '/';
   const value = JSON.stringify(getConfigFromSdkOptions(options));
@@ -57,10 +62,20 @@ const setConfigCookie = (options: SdkOptions, productDetails: ProductDetails) =>
   document.cookie = cookie;
 };
 
-const removeConfigCookie = (productDetails: ProductDetails) => {
+export const removeConfigCookie = (
+  options: SdkOptions,
+  productDetails: ProductDetails,
+  previousCookieDomain: string | undefined,
+  previousCookiePath: string | undefined
+) => {
   document.cookie =
-    productDetails.cookieName + '_config' + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT;path=/';
-  console.log(document.cookie);
+    productDetails.cookieName +
+    '_config' +
+    '=;path=' +
+    (previousCookiePath ?? '/') +
+    ';domain=' +
+    (previousCookieDomain ?? '') +
+    ';expires=Tue, 1 Jan 1980 23:59:59 GMT';
 };
 
 const getConfigCookie = (productDetails: ProductDetails) => {

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -59,7 +59,8 @@ const setConfigCookie = (options: SdkOptions, productDetails: ProductDetails) =>
 
 const removeConfigCookie = (productDetails: ProductDetails) => {
   document.cookie =
-    productDetails.cookieName + '_config' + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
+    productDetails.cookieName + '_config' + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT;path=/';
+  console.log(document.cookie);
 };
 
 const getConfigCookie = (productDetails: ProductDetails) => {

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -53,7 +53,7 @@ export const removeConfig = (previousOptions: SdkOptions, productDetails: Produc
   }
 };
 
-export const setConfigCookie = (options: SdkOptions, productDetails: ProductDetails) => {
+const setConfigCookie = (options: SdkOptions, productDetails: ProductDetails) => {
   const cookieDomain = options.cookieDomain;
   const path = options.cookiePath ?? '/';
   const value = JSON.stringify(getConfigFromSdkOptions(options));
@@ -62,11 +62,10 @@ export const setConfigCookie = (options: SdkOptions, productDetails: ProductDeta
   if (typeof cookieDomain !== 'undefined') {
     cookie += ';domain=' + cookieDomain;
   }
-  const testbefore = document.cookie;
   document.cookie = cookie;
 };
 
-export const removeConfigCookie = (productDetails: ProductDetails, previousOptions: SdkOptions) => {
+const removeConfigCookie = (productDetails: ProductDetails, previousOptions: SdkOptions) => {
   document.cookie =
     productDetails.cookieName +
     '_config' +

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -81,7 +81,7 @@ const getConfigCookie = (productDetails: ProductDetails) => {
   if (docCookie) {
     const payload = docCookie
       .split('; ')
-      .filter((row) => row.startsWith(productDetails.cookieName + '_config' + '='))[1];
+      .find((row) => row.startsWith(productDetails.cookieName + '_config' + '='));
     if (payload) {
       return decodeURIComponent(payload.split('=')[1]);
     }

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -39,15 +39,18 @@ export const loadConfig = (
 export const updateConfig = (
   options: SdkOptions,
   productDetails: ProductDetails,
-  previousCookieDomain: string | undefined,
-  previousCookiePath: string | undefined
+  previousOptions: SdkOptions
 ) => {
-  if (options.useCookie) {
-    removeConfigCookie(options, productDetails, previousCookieDomain, previousCookiePath);
+  removeConfig(previousOptions, productDetails);
+  storeConfig(options, productDetails);
+};
+
+export const removeConfig = (previousOptions: SdkOptions, productDetails: ProductDetails) => {
+  if (previousOptions.useCookie) {
+    removeConfigCookie(productDetails, previousOptions);
   } else {
     removeConfigFromLocalStorage(productDetails);
   }
-  storeConfig(options, productDetails);
 };
 
 export const setConfigCookie = (options: SdkOptions, productDetails: ProductDetails) => {
@@ -59,22 +62,18 @@ export const setConfigCookie = (options: SdkOptions, productDetails: ProductDeta
   if (typeof cookieDomain !== 'undefined') {
     cookie += ';domain=' + cookieDomain;
   }
+  const testbefore = document.cookie;
   document.cookie = cookie;
 };
 
-export const removeConfigCookie = (
-  options: SdkOptions,
-  productDetails: ProductDetails,
-  previousCookieDomain: string | undefined,
-  previousCookiePath: string | undefined
-) => {
+export const removeConfigCookie = (productDetails: ProductDetails, previousOptions: SdkOptions) => {
   document.cookie =
     productDetails.cookieName +
     '_config' +
     '=;path=' +
-    (previousCookiePath ?? '/') +
+    (previousOptions.cookiePath ?? '/') +
     ';domain=' +
-    (previousCookieDomain ?? '') +
+    (previousOptions.cookieDomain ?? '') +
     ';expires=Tue, 1 Jan 1980 23:59:59 GMT';
 };
 

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -36,6 +36,15 @@ export const loadConfig = (
   }
 };
 
+export const updateConfig = (options: SdkOptions, productDetails: ProductDetails) => {
+  if (options.useCookie) {
+    removeConfigCookie(productDetails);
+  } else {
+    removeConfigFromLocalStorage(productDetails);
+  }
+  storeConfig(options, productDetails);
+};
+
 const setConfigCookie = (options: SdkOptions, productDetails: ProductDetails) => {
   const cookieDomain = options.cookieDomain;
   const path = options.cookiePath ?? '/';
@@ -58,7 +67,7 @@ const getConfigCookie = (productDetails: ProductDetails) => {
   if (docCookie) {
     const payload = docCookie
       .split('; ')
-      .find((row) => row.startsWith(productDetails.cookieName + '_config' + '='));
+      .filter((row) => row.startsWith(productDetails.cookieName + '_config' + '='))[1];
     if (payload) {
       return decodeURIComponent(payload.split('=')[1]);
     }

--- a/src/cookieManager.ts
+++ b/src/cookieManager.ts
@@ -1,4 +1,5 @@
 import { isValidIdentity, Identity, OptoutIdentity, isOptoutIdentity } from './Identity';
+import { SdkOptions } from './sdkOptions';
 
 export type CookieOptions = {
   cookieDomain?: string;
@@ -52,13 +53,13 @@ export class CookieManager {
     }
     document.cookie = cookie;
   }
-  public removeCookie() {
+  public removeCookie(previousOptions: SdkOptions) {
     document.cookie =
       this._cookieName +
       '=;path=' +
-      (this._opts.cookiePath ?? '/') +
+      (previousOptions.cookiePath ?? '/') +
       ';domain=' +
-      (this._opts.cookieDomain ?? '') +
+      (previousOptions.cookieDomain ?? '') +
       ';expires=Tue, 1 Jan 1980 23:59:59 GMT';
   }
   private getCookie() {

--- a/src/cookieManager.ts
+++ b/src/cookieManager.ts
@@ -51,9 +51,11 @@ export class CookieManager {
       cookie += ';domain=' + this._opts.cookieDomain;
     }
     document.cookie = cookie;
+    let testcookie = document.cookie;
+    console.log(testcookie);
   }
-  public removeCookie() {
-    document.cookie = this._cookieName + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
+  public async removeCookie() {
+    document.cookie = this._cookieName + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT;path=/';
   }
   private getCookie() {
     const docCookie = document.cookie;

--- a/src/cookieManager.ts
+++ b/src/cookieManager.ts
@@ -51,11 +51,15 @@ export class CookieManager {
       cookie += ';domain=' + this._opts.cookieDomain;
     }
     document.cookie = cookie;
-    let testcookie = document.cookie;
-    console.log(testcookie);
   }
   public async removeCookie() {
-    document.cookie = this._cookieName + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT;path=/';
+    document.cookie =
+      this._cookieName +
+      '=;path=' +
+      (this._opts.cookiePath ?? '/') +
+      ';domain=' +
+      (this._opts.cookieDomain ?? '') +
+      ';expires=Tue, 1 Jan 1980 23:59:59 GMT';
   }
   private getCookie() {
     const docCookie = document.cookie;

--- a/src/cookieManager.ts
+++ b/src/cookieManager.ts
@@ -52,7 +52,7 @@ export class CookieManager {
     }
     document.cookie = cookie;
   }
-  public async removeCookie() {
+  public removeCookie() {
     document.cookie =
       this._cookieName +
       '=;path=' +

--- a/src/initCallbacks.ts
+++ b/src/initCallbacks.ts
@@ -21,24 +21,35 @@ export enum IdentityStatus {
   OPTOUT = -4,
 }
 
-export function notifyInitCallback(
-  options: InitCallbackOptions,
-  status: IdentityStatus,
-  statusText: string,
-  advertisingToken: string | undefined,
-  logger: Logger
-) {
-  if (options.callback) {
-    const payload = {
-      advertisingToken: advertisingToken,
-      advertising_token: advertisingToken,
-      status: status,
-      statusText: statusText,
-    };
-    try {
-      options.callback(payload);
-    } catch (exception) {
-      logger.warn('SDK init callback threw an exception', exception);
-    }
+export class InitCallbackManager {
+  private _callbacks: InitCallbackFunction[];
+
+  constructor(opts: InitCallbackOptions) {
+    this._callbacks = opts.callback ? [opts.callback] : [];
+  }
+
+  public addCallback(callback: InitCallbackFunction) {
+    this._callbacks.push(callback);
+  }
+
+  public notifyInitCallbacks(
+    status: IdentityStatus,
+    statusText: string,
+    advertisingToken: string | undefined,
+    logger: Logger
+  ) {
+    this._callbacks.forEach((callback) => {
+      const payload = {
+        advertisingToken: advertisingToken,
+        advertising_token: advertisingToken,
+        status: status,
+        statusText: statusText,
+      };
+      try {
+        callback(payload);
+      } catch (exception) {
+        logger.warn('SDK init callback threw an exception', exception);
+      }
+    });
   }
 }

--- a/src/initCallbacks.ts
+++ b/src/initCallbacks.ts
@@ -22,14 +22,18 @@ export enum IdentityStatus {
 }
 
 export class InitCallbackManager {
-  private _callbacks: InitCallbackFunction[];
+  private _initCallbacks: InitCallbackFunction[];
 
   constructor(opts: InitCallbackOptions) {
-    this._callbacks = opts.callback ? [opts.callback] : [];
+    this._initCallbacks = opts.callback ? [opts.callback] : [];
   }
 
-  public addCallback(callback: InitCallbackFunction) {
-    this._callbacks.push(callback);
+  public addInitCallback(callback: InitCallbackFunction) {
+    this._initCallbacks.push(callback);
+  }
+
+  public getInitCallbacks() {
+    return this._initCallbacks;
   }
 
   public notifyInitCallbacks(
@@ -38,7 +42,7 @@ export class InitCallbackManager {
     advertisingToken: string | undefined,
     logger: Logger
   ) {
-    this._callbacks.forEach((callback) => {
+    this._initCallbacks.forEach((initCallback) => {
       const payload = {
         advertisingToken: advertisingToken,
         advertising_token: advertisingToken,
@@ -46,7 +50,7 @@ export class InitCallbackManager {
         statusText: statusText,
       };
       try {
-        callback(payload);
+        initCallback(payload);
       } catch (exception) {
         logger.warn('SDK init callback threw an exception', exception);
       }

--- a/src/integrationTests/basic.test.ts
+++ b/src/integrationTests/basic.test.ts
@@ -963,10 +963,10 @@ testCookieAndLocalStorage(() => {
       expect(xhrMock.send).toHaveBeenCalledTimes(1);
       expect(xhrMock.abort).toHaveBeenCalledTimes(1);
     });
-    test('should prevent subsequent calls to init()', () => {
-      uid2.abort();
-      expect(() => uid2.init({ callback: () => {} })).toThrow();
-    });
+    // test('should prevent subsequent calls to init()', () => {
+    //   uid2.abort();
+    //   expect(() => uid2.init({ callback: () => {} })).toThrow();
+    // });
   });
 
   describe('disconnect()', () => {
@@ -999,10 +999,10 @@ testCookieAndLocalStorage(() => {
       expect(xhrMock.send).toHaveBeenCalledTimes(1);
       expect(xhrMock.abort).toHaveBeenCalledTimes(1);
     });
-    test('should prevent subsequent calls to init()', () => {
-      uid2.disconnect();
-      expect(() => uid2.init({ callback: () => {} })).toThrow();
-    });
+    // test('should prevent subsequent calls to init()', () => {
+    //   uid2.disconnect();
+    //   expect(() => uid2.init({ callback: () => {} })).toThrow();
+    // });
     test('should switch to unavailable state', () => {
       uid2.init({
         callback: callback,

--- a/src/integrationTests/basic.test.ts
+++ b/src/integrationTests/basic.test.ts
@@ -134,10 +134,10 @@ testCookieAndLocalStorage(() => {
     });
   });
 
-  test('init() should fail if called multiple times', () => {
-    uid2.init({ callback: () => {} });
-    expect(() => uid2.init({ callback: () => {} })).toThrow();
-  });
+  // test('init() should fail if called multiple times', () => {
+  //   uid2.init({ callback: () => {} });
+  //   expect(() => uid2.init({ callback: () => {} })).toThrow();
+  // });
 
   describe('when initialised without identity', () => {
     describe('when uid2 value is not available', () => {

--- a/src/integrationTests/basic.test.ts
+++ b/src/integrationTests/basic.test.ts
@@ -134,10 +134,10 @@ testCookieAndLocalStorage(() => {
     });
   });
 
-  // test('init() should fail if called multiple times', () => {
-  //   uid2.init({ callback: () => {} });
-  //   expect(() => uid2.init({ callback: () => {} })).toThrow();
-  // });
+  test('init() should not fail if called multiple times', () => {
+    uid2.init({ callback: () => {}, identity: makeIdentityV2() });
+    expect(() => uid2.init({ callback: () => {} })).not.toThrow();
+  });
 
   describe('when initialised without identity', () => {
     describe('when uid2 value is not available', () => {
@@ -963,10 +963,10 @@ testCookieAndLocalStorage(() => {
       expect(xhrMock.send).toHaveBeenCalledTimes(1);
       expect(xhrMock.abort).toHaveBeenCalledTimes(1);
     });
-    // test('should prevent subsequent calls to init()', () => {
-    //   uid2.abort();
-    //   expect(() => uid2.init({ callback: () => {} })).toThrow();
-    // });
+    test('should prevent subsequent calls to init()', () => {
+      uid2.abort();
+      expect(() => uid2.init({ callback: () => {} })).toThrow();
+    });
   });
 
   describe('disconnect()', () => {
@@ -999,10 +999,10 @@ testCookieAndLocalStorage(() => {
       expect(xhrMock.send).toHaveBeenCalledTimes(1);
       expect(xhrMock.abort).toHaveBeenCalledTimes(1);
     });
-    // test('should prevent subsequent calls to init()', () => {
-    //   uid2.disconnect();
-    //   expect(() => uid2.init({ callback: () => {} })).toThrow();
-    // });
+    test('should prevent subsequent calls to init()', () => {
+      uid2.disconnect();
+      expect(() => uid2.init({ callback: () => {} })).toThrow();
+    });
     test('should switch to unavailable state', () => {
       uid2.init({
         callback: callback,

--- a/src/integrationTests/euidSdk.test.ts
+++ b/src/integrationTests/euidSdk.test.ts
@@ -181,7 +181,6 @@ describe('Store config EUID', () => {
     });
   });
   describe('when useCookie is true', () => {
-    const previousOptions = options;
     test('can successfully clear the config cookie', () => {
       (sdkWindow.__euid as EUID).init({
         callback: callback,

--- a/src/integrationTests/euidSdk.test.ts
+++ b/src/integrationTests/euidSdk.test.ts
@@ -181,6 +181,7 @@ describe('Store config EUID', () => {
     });
   });
   describe('when useCookie is true', () => {
+    const previousOptions = options;
     test('can successfully clear the config cookie', () => {
       (sdkWindow.__euid as EUID).init({
         callback: callback,

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -498,7 +498,11 @@ describe('multiple init calls', () => {
     });
   });
 
-  describe('adding a callback when no callbacks exist before', () => {
+  describe('setting a new identity and make sure callback is called', () => {
+    const newIdentity = makeIdentity({
+      advertising_token: 'new_advertising_token',
+      identity_expires: Date.now() + 300000,
+    });
     beforeEach(() => {
       uid2.init({
         identity: identity,
@@ -506,19 +510,30 @@ describe('multiple init calls', () => {
         cookiePath: cookiePath,
         refreshRetryPeriod: 12345,
         useCookie: true,
+        callback: callback,
       });
       uid2.init({
         useCookie: false,
-        callback: callback,
+        identity: newIdentity,
       });
     });
     test('should contain one init callback', () => {
-      const initCallbacks = uid2.getInitCallbacks();
-      expect(initCallbacks).toEqual([callback]);
+      expect(callback).toHaveBeenCalled();
     });
   });
 
-  describe('adding multiple callbacks that are different', () => {
+  describe('adding multiple callbacks and then setting new identity', () => {
+    const newIdentity = makeIdentity({
+      advertising_token: 'new_advertising_token',
+      identity_expires: Date.now() + 300000,
+    });
+    const callback2 = jest.fn(() => {
+      return 'testing one';
+    });
+    const callback3 = jest.fn(() => {
+      return 'testing two';
+    });
+
     beforeEach(() => {
       uid2.init({
         callback: callback,
@@ -529,19 +544,19 @@ describe('multiple init calls', () => {
         useCookie: false,
       });
       uid2.init({
-        callback: jest.fn(() => {
-          return 'testing one';
-        }),
+        callback: callback2,
       });
       uid2.init({
-        callback: jest.fn(() => {
-          return 'testing two';
-        }),
+        callback: callback3,
+      });
+      uid2.init({
+        identity: newIdentity,
       });
     });
     test('should contain only one init callback function', () => {
-      const initCallbacks = uid2.getInitCallbacks();
-      expect(initCallbacks?.length).toEqual(3);
+      expect(callback).toHaveBeenCalled();
+      expect(callback2).toHaveBeenCalled();
+      expect(callback3).toHaveBeenCalled();
     });
   });
 });

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -21,6 +21,9 @@ beforeEach(() => {
   cookieMock = new mocks.CookieMock(sdkWindow.document);
   removeUid2Cookie();
   removeUid2LocalStorage();
+  localStorage.removeItem('UID2-sdk-identity_config');
+  document.cookie = UID2.COOKIE_NAME + '_config' + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
+  document.cookie = UID2.COOKIE_NAME + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
 });
 
 afterEach(() => {
@@ -251,262 +254,263 @@ describe('multiple init calls', () => {
   //   });
   // });
 
-  // describe('invalid options given in first init call', () => {
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //     });
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //     });
-  //   });
-  //   test('should throw error', () => {
-  //     //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
-  //   });
-  // });
-
-  // describe('invalid options given in second init call', () => {
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //     });
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //     });
-  //   });
-  //   test('should throw error', () => {
-  //     expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
-  //   });
-  // });
-
   // describe('new base URL is given', () => {
+  //   const identity = makeIdentity({
+  //     refresh_from: Date.now() - 100000,
+  //   });
+
+  //   const oldBaseUrl = baseUrl;
+  //   const newBaseUrl = 'http://example';
+
   //   beforeEach(() => {
   //     uid2.init({
   //       callback: callback,
   //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
+  //       baseUrl: oldBaseUrl,
   //     });
   //   });
   //   test('should use new base url', () => {
   //     uid2.init({
-  //       baseUrl: 'http://test',
-  //     });
-  //     //expect(xhrMock.open.mock.calls.length).toBe(1);
-  //     expect(xhrMock.open.mock.calls[0][1]).not.toContain(baseUrl);
-  //     expect(xhrMock.open.mock.calls[0][1]).toContain('http://test');
-  //   });
-
-  //   test('should use old base url', () => {
-  //     uid2.init({
-  //       cookiePath: cookiePath,
-  //     });
-  //     //expect(xhrMock.open.mock.calls.length).toBe(1);
-  //     expect(xhrMock.open.mock.calls[0][1]).not.toContain('http://test');
-  //     expect(xhrMock.open.mock.calls[0][1]).toContain(baseUrl);
-  //   });
-  // });
-
-  // describe('new identity provided and old identity does not exist', () => {
-  //   const newIdentity = makeIdentity();
-
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //     });
-  //     uid2.init({
-  //       identity: newIdentity,
-  //     });
-  //   });
-  //   test('should create new identity', () => {
-  //     test('should set value', () => {
-  //       expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
-  //     });
-  //     test('should set refresh timer', () => {
-  //       expect(setTimeout).toHaveBeenCalledTimes(1);
-  //       expect(clearTimeout).not.toHaveBeenCalled();
-  //     });
-  //     test('should be in available state', () => {
-  //       (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
-  //     });
-  //   });
-  // });
-
-  // describe('new identity provided but expired', () => {
-  //   const newIdentity = makeIdentity({ refresh_expires: Date.now() - 100000 });
-
-  //   beforeEach(() => {
-  //     uid2.init({
   //       callback: callback,
   //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
+  //       baseUrl: newBaseUrl,
   //     });
-  //     uid2.init({
-  //       identity: newIdentity,
-  //     });
-  //   });
-  //   test('should not update the identity', () => {
-  //     test('should set value', () => {
-  //       expect(getUid2(useCookie).advertising_token).toBe(identity.advertising_token);
-  //     });
-  //     test('should set refresh timer', () => {
-  //       expect(setTimeout).toHaveBeenCalledTimes(1);
-  //       expect(clearTimeout).not.toHaveBeenCalled();
-  //     });
-  //     test('should be in available state', () => {
-  //       (expect(uid2) as any).toBeInAvailableState(identity.advertising_token);
-  //     });
-  //   });
-  // });
+  //     console.log(xhrMock.open.mock.calls);
+  //     expect(xhrMock.open.mock.calls.length).toBe(1);
+  //     expect(xhrMock.open.mock.calls[0][1]).not.toContain(oldBaseUrl);
+  //expect(xhrMock.open.mock.calls[0][1]).toContain(newBaseUrl);
+  //});
 
-  // describe('new identity provided but expires before old identity', () => {
-  //   const oldIdentity = makeIdentity({ refresh_expires: Date.now() + 5000 });
-  //   const newIdentity = makeIdentity({ refresh_expires: Date.now() + 100000 });
+  //   // test('should use old base url', () => {
+  //   //   uid2.init({
+  //   //     cookiePath: cookiePath,
+  //   //   });
+  //   //   expect(xhrMock.open.mock.calls.length).toBe(1);
+  //   //   expect(xhrMock.open.mock.calls[0][1]).not.toContain(newBaseUrl);
+  //   //   expect(xhrMock.open.mock.calls[0][1]).toContain(oldBaseUrl);
+  //   // });
+  //});
 
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: oldIdentity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //     });
-  //     uid2.init({
-  //       identity: newIdentity,
-  //     });
-  //   });
-  //   test('should not update the identity', () => {
-  //     test('should set value', () => {
-  //       expect(getUid2(useCookie).advertising_token).toBe(oldIdentity.advertising_token);
-  //     });
-  //     test('should set refresh timer', () => {
-  //       expect(setTimeout).toHaveBeenCalledTimes(1);
-  //       expect(clearTimeout).not.toHaveBeenCalled();
-  //     });
-  //     test('should be in available state', () => {
-  //       (expect(uid2) as any).toBeInAvailableState(oldIdentity.advertising_token);
-  //     });
-  //   });
-  // });
+  describe('new identity provided and old identity does not exist', () => {
+    const newIdentity = makeIdentity();
+    const useCookie = true;
 
-  // describe('new identity provided and expires after old identity', () => {
-  //   const newIdentity = makeIdentity();
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+        useCookie: useCookie,
+      });
+      uid2.init({
+        identity: newIdentity,
+      });
+    });
 
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //     });
-  //     uid2.init({
-  //       identity: newIdentity,
-  //     });
-  //   });
-  //   test('should update identity to the new one', () => {
-  //     test('should set value', () => {
-  //       expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
-  //     });
-  //     test('should set refresh timer', () => {
-  //       expect(setTimeout).toHaveBeenCalledTimes(1);
-  //       expect(clearTimeout).not.toHaveBeenCalled();
-  //     });
-  //     test('should be in available state', () => {
-  //       (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
-  //     });
-  //   });
-  // });
+    test('should set value to new identity', () => {
+      expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
+    });
+    test('should set refresh timer and call it once', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('new identity should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
+    });
+  });
 
-  // describe('new cookie domain and new cookie path', () => {
-  //   const newCookiePath = '/';
-  //   const newCookieDomain = 'www.uidapi.com';
+  describe('new identity provided but expired', () => {
+    const newIdentity = makeIdentity({ refresh_expires: Date.now() - 100000 });
+    const useCookie = true;
 
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //       cookieDomain: cookieDomain,
-  //       useCookie: true,
-  //     });
-  //     uid2.init({
-  //       cookiePath: newCookiePath,
-  //       cookieDomain: newCookieDomain,
-  //     });
-  //   });
-  //   test('should update cookie manager and config cookie', () => {
-  //     const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
-  //     //expect(cookie).toContain(`Domain=${newCookieDomain};`);
-  //     //expect(cookie + ';').toContain(`Path=${newCookiePath};`);
-  //     expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
-  //     expect(getConfigCookie() + ';').toHaveProperty('cookiePath', newCookiePath);
-  //   });
-  // });
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+        useCookie: useCookie,
+      });
+      uid2.init({
+        identity: newIdentity,
+      });
+    });
+    test('should set value to old identity', () => {
+      expect(getUid2(useCookie).advertising_token).toBe(identity.advertising_token);
+    });
+    test('should set refresh timer once', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('old ideneity should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(identity.advertising_token);
+    });
+  });
 
-  // describe('new cookie domain only', () => {
-  //   const newCookieDomain = 'www.uidapi.com';
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //       useCookie: true,
-  //     });
-  //     uid2.init({
-  //       cookieDomain: newCookieDomain,
-  //     });
-  //   });
-  //   test('should update cookie manager', () => {
-  //     const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
-  //     //expect(cookie).toContain(`Domain=${newCookieDomain};`);
-  //     //expect(cookie + ';').toContain(`Path=${cookiePath};`);
-  //     expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
-  //     expect(getConfigCookie() + ';').toHaveProperty('cookiePath', cookiePath);
-  //   });
-  // });
+  describe('new identity provided but expires before old identity', () => {
+    const oldIdentity = makeIdentity({ refresh_expires: Date.now() + 5000 });
+    const newIdentity = makeIdentity({ refresh_expires: Date.now() + 100000 });
+    const useCookie = true;
 
-  // describe('new cookie path only', () => {
-  //   const newCookiePath = '/';
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: oldIdentity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+        useCookie: useCookie,
+      });
+      uid2.init({
+        identity: newIdentity,
+      });
+    });
 
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookieDomain: cookieDomain,
-  //       cookiePath: cookiePath,
-  //       useCookie: true,
-  //     });
-  //     uid2.init({
-  //       cookiePath: newCookiePath,
-  //     });
-  //   });
+    test('should set value', () => {
+      expect(getUid2(useCookie).advertising_token).toBe(oldIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(oldIdentity.advertising_token);
+    });
+  });
 
-  //   test('should update cookie manager', () => {
-  //     const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
-  //     expect(cookie).toContain(`Domain=${cookieDomain};`);
-  //     expect(cookie + ';').toContain(`Path=${newCookiePath};`);
-  //     const configCookie = getConfigCookie();
-  //     expect(configCookie).toHaveProperty('cookieDomain', cookieDomain);
-  //     expect(configCookie).toHaveProperty('cookiePath', newCookiePath);
-  //   });
-  // });
+  describe('new identity provided and expires after old identity', () => {
+    const newIdentity = makeIdentity();
+    const useCookie = true;
+
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+        useCookie: useCookie,
+      });
+      uid2.init({
+        identity: newIdentity,
+      });
+    });
+
+    test('should set value', () => {
+      expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
+    });
+  });
+
+  describe('new identity provided and use cookie is false', () => {
+    const newIdentity = makeIdentity();
+    const useCookie = false;
+
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+        useCookie: useCookie,
+      });
+      uid2.init({
+        identity: newIdentity,
+      });
+    });
+
+    test('should set value', () => {
+      expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
+    });
+    test('should set refresh timer', () => {
+      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(clearTimeout).not.toHaveBeenCalled();
+    });
+    test('should be in available state', () => {
+      (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
+    });
+  });
+
+  describe('new cookie domain and new cookie path', () => {
+    const newCookiePath = '/';
+    const newCookieDomain = 'www.test.com';
+
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+        cookieDomain: cookieDomain,
+        useCookie: true,
+      });
+      uid2.init({
+        cookiePath: newCookiePath,
+        cookieDomain: newCookieDomain,
+      });
+    });
+    test('should update cookie manager and config cookie', () => {
+      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+      expect(cookie).toContain(`Domain=${newCookieDomain};`);
+      expect(cookie + ';').toContain(`Path=${newCookiePath};`);
+      //expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
+      //expect(getConfigCookie() + ';').toHaveProperty('cookiePath', newCookiePath);
+    });
+  });
+
+  describe('new cookie domain only', () => {
+    const newCookieDomain = 'www.uidapi.com';
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+        useCookie: true,
+      });
+      uid2.init({
+        cookieDomain: newCookieDomain,
+      });
+    });
+    test('should update cookie manager', () => {
+      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+      expect(cookie).toContain(`Domain=${newCookieDomain};`);
+      expect(cookie + ';').toContain(`Path=${cookiePath};`);
+      //expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
+      //expect(getConfigCookie() + ';').toHaveProperty('cookiePath', cookiePath);
+    });
+  });
+
+  describe('new cookie path only', () => {
+    const newCookiePath = '/';
+
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookieDomain: cookieDomain,
+        cookiePath: cookiePath,
+        useCookie: true,
+      });
+      uid2.init({
+        cookiePath: newCookiePath,
+      });
+    });
+
+    test('should update cookie manager', () => {
+      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+      expect(cookie).toContain(`Domain=${cookieDomain};`);
+      expect(cookie + ';').toContain(`Path=${newCookiePath};`);
+      //const configCookie = getConfigCookie();
+      //expect(configCookie).toHaveProperty('cookieDomain', cookieDomain);
+      //expect(configCookie).toHaveProperty('cookiePath', newCookiePath);
+    });
+  });
 
   describe('new refreshretry period', () => {
     beforeEach(() => {
@@ -550,6 +554,7 @@ describe('multiple init calls', () => {
   //       expect(cookie).toBeNull();
   //     });
   //   });
+  // });
 
   //   describe('adding a callback when no callbacks exist before', () => {
   //     beforeEach(() => {

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -9,6 +9,7 @@ let callback: any;
 let uid2: UID2;
 let xhrMock: any;
 let cookieMock: any;
+let cookieMock2: any;
 
 mocks.setupFakeTime();
 
@@ -24,8 +25,8 @@ beforeEach(() => {
   removeUid2Cookie();
   removeUid2LocalStorage();
   localStorage.removeItem('UID2-sdk-identity_config');
-  document.cookie = UID2.COOKIE_NAME + '_config' + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
-  document.cookie = UID2.COOKIE_NAME + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
+  //document.cookie = UID2.COOKIE_NAME + '_config' + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
+  //document.cookie = UID2.COOKIE_NAME + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
 });
 
 afterEach(() => {
@@ -256,42 +257,38 @@ describe('multiple init calls', () => {
   //   });
   // });
 
-  // describe('new base URL is given', () => {
-  //   const identity = makeIdentity({
-  //     refresh_from: Date.now() - 100000,
-  //   });
+  describe('new base URL is given', () => {
+    const identity = makeIdentity({
+      refresh_from: Date.now() - 100000,
+    });
 
-  //   const oldBaseUrl = baseUrl;
-  //   const newBaseUrl = 'http://example';
+    const oldBaseUrl = baseUrl;
+    const newBaseUrl = 'http://example';
 
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: oldBaseUrl,
-  //     });
-  //   });
-  //   test('should use new base url', () => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: newBaseUrl,
-  //     });
-  //     console.log(xhrMock.open.mock.calls);
-  //     expect(xhrMock.open.mock.calls.length).toBe(1);
-  //     expect(xhrMock.open.mock.calls[0][1]).not.toContain(oldBaseUrl);
-  //expect(xhrMock.open.mock.calls[0][1]).toContain(newBaseUrl);
-  //});
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: oldBaseUrl,
+        useCookie: true,
+      });
+    });
+    test('should use new base url', () => {
+      uid2.init({
+        baseUrl: newBaseUrl,
+      });
+      const configCookie = getConfigCookie();
+      expect(configCookie).toHaveProperty('baseUrl', newBaseUrl);
+    });
 
-  //   // test('should use old base url', () => {
-  //   //   uid2.init({
-  //   //     cookiePath: cookiePath,
-  //   //   });
-  //   //   expect(xhrMock.open.mock.calls.length).toBe(1);
-  //   //   expect(xhrMock.open.mock.calls[0][1]).not.toContain(newBaseUrl);
-  //   //   expect(xhrMock.open.mock.calls[0][1]).toContain(oldBaseUrl);
-  //   // });
-  //});
+    test('should use old base url', () => {
+      uid2.init({
+        cookiePath: cookiePath,
+      });
+      const configCookie = getConfigCookie();
+      expect(configCookie).toHaveProperty('baseUrl', oldBaseUrl);
+    });
+  });
 
   describe('new identity provided and old identity does not exist', () => {
     const newIdentity = makeIdentity();
@@ -464,30 +461,35 @@ describe('multiple init calls', () => {
   //   });
   // });
 
-  describe('new cookie domain only', () => {
-    const newCookieDomain = 'test.uidapi.com';
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-        cookieDomain: newCookieDomain,
-        useCookie: true,
-      });
-      uid2.init({
-        cookieDomain: cookieDomain,
-      });
-    });
-    test('should update cookie manager', () => {
-      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
-      expect(cookie).toContain(`Domain=${newCookieDomain};`);
-      expect(cookie + ';').toContain(`Path=${cookiePath};`);
-      const configCookie = getConfigCookie();
-      expect(configCookie).toHaveProperty('cookieDomain', newCookieDomain);
-      expect(configCookie).toHaveProperty('cookiePath', cookiePath);
-    });
-  });
+  // describe('new cookie domain only', () => {
+  //   const newCookieDomain = 'www.test.com';
+  //   const newMockUrl = `http://${newCookieDomain}/test/index.html`;
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //       cookieDomain: cookieDomain,
+  //       useCookie: true,
+  //     });
+  //     jest.spyOn(document, 'URL', 'get').mockImplementation(() => newMockUrl);
+  //     cookieMock = new mocks.CookieMock(sdkWindow.document);
+  //     jest.spyOn(document, 'URL', 'get').mockImplementation(() => mockUrl);
+  //     cookieMock2 = new mocks.CookieMock(sdkWindow.document);
+  //     uid2.init({
+  //       cookieDomain: newCookieDomain,
+  //     });
+  //   });
+  //   test('should update cookie manager', () => {
+  //     const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+  //     expect(cookie).toContain(`Domain=${newCookieDomain};`);
+  //     expect(cookie + ';').toContain(`Path=${cookiePath};`);
+  //     const configCookie = getConfigCookie();
+  //     expect(configCookie).toHaveProperty('cookieDomain', newCookieDomain);
+  //     expect(configCookie).toHaveProperty('cookiePath', cookiePath);
+  //   });
+  // });
 
   describe('new cookie path only', () => {
     const newCookiePath = '/';
@@ -585,53 +587,52 @@ describe('multiple init calls', () => {
     });
   });
 
-  //   describe('adding a callback when no callbacks exist before', () => {
-  //     beforeEach(() => {
-  //       uid2.init({
-  //         identity: identity,
-  //         baseUrl: baseUrl,
-  //         cookiePath: cookiePath,
-  //         refreshRetryPeriod: 12345,
-  //         useCookie: true,
-  //       });
-  //       uid2.init({
-  //         useCookie: false,
-  //         callback: callback,
-  //       });
+  // describe('adding a callback when no callbacks exist before', () => {
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //       refreshRetryPeriod: 12345,
+  //       useCookie: true,
   //     });
-  //     test('should change config from cookie to local storage', () => {
-  //       test('should store config in local storage', () => {
-  //         const storageConfig = getConfigStorage();
-  //         expect(storageConfig).toBeInstanceOf(Object);
-  //         expect(storageConfig).toHaveProperty('cookiePath');
-  //         const cookie = getConfigCookie();
-  //         expect(cookie).toBeNull();
-  //       });
+  //     uid2.init({
+  //       useCookie: false,
+  //       callback: callback,
   //     });
   //   });
-
-  //   describe('adding a callback', () => {
-  //     beforeEach(() => {
-  //       uid2.init({
-  //         callback: callback,
-  //         identity: identity,
-  //         baseUrl: baseUrl,
-  //         cookiePath: cookiePath,
-  //         refreshRetryPeriod: 12345,
-  //         useCookie: false,
-  //       });
-  //       uid2.init({
-  //         callback: jest.fn(),
-  //       });
+  //   test('should change config from cookie to local storage', () => {
+  //     test('should store config in local storage', () => {
+  //       const storageConfig = getConfigStorage();
+  //       expect(storageConfig).toBeInstanceOf(Object);
+  //       expect(storageConfig).toHaveProperty('cookiePath');
+  //       const cookie = getConfigCookie();
+  //       expect(cookie).toBeNull();
   //     });
-  //     test('should change config from local storage to cookie', () => {
-  //       test('should store config in cookie', () => {
-  //         const cookie = getConfigCookie();
-  //         expect(cookie).toBeInstanceOf(Object);
-  //         expect(cookie).toHaveProperty('cookiePath');
-  //         const storageConfig = getConfigStorage();
-  //         expect(storageConfig).toBeNull();
-  //       });
+  //   });
+  // });
+
+  // describe('adding a callback', () => {
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //       refreshRetryPeriod: 12345,
+  //       useCookie: false,
+  //     });
+  //     uid2.init({
+  //       callback: jest.fn(),
+  //     });
+  //   });
+  //   test('should change config from local storage to cookie', () => {
+  //     test('should store config in cookie', () => {
+  //       const cookie = getConfigCookie();
+  //       expect(cookie).toBeInstanceOf(Object);
+  //       expect(cookie).toHaveProperty('cookiePath');
+  //       const storageConfig = getConfigStorage();
+  //       expect(storageConfig).toBeNull();
   //     });
   //   });
   // });

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -9,7 +9,6 @@ let callback: any;
 let uid2: UID2;
 let xhrMock: any;
 let cookieMock: any;
-let cookieMock2: any;
 
 mocks.setupFakeTime();
 
@@ -434,64 +433,7 @@ describe('multiple init calls', () => {
     });
   });
 
-  // describe('new cookie domain and new cookie path', () => {
-  //   const newCookiePath = '/';
-  //   const newCookieDomain = 'www.test.com';
-
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //       cookieDomain: cookieDomain,
-  //       useCookie: true,
-  //     });
-  //     uid2.init({
-  //       cookiePath: newCookiePath,
-  //       cookieDomain: newCookieDomain,
-  //     });
-  //   });
-  //   test('should update cookie manager and config cookie', () => {
-  //     const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
-  //     expect(cookie).toContain(`Domain=${newCookieDomain};`);
-  //     expect(cookie + ';').toContain(`Path=${newCookiePath};`);
-  //     expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
-  //     expect(getConfigCookie()).toHaveProperty('cookiePath', newCookiePath);
-  //   });
-  // });
-
-  // describe('new cookie domain only', () => {
-  //   const newCookieDomain = 'www.test.com';
-  //   const newMockUrl = `http://${newCookieDomain}/test/index.html`;
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //       cookieDomain: cookieDomain,
-  //       useCookie: true,
-  //     });
-  //     jest.spyOn(document, 'URL', 'get').mockImplementation(() => newMockUrl);
-  //     cookieMock = new mocks.CookieMock(sdkWindow.document);
-  //     jest.spyOn(document, 'URL', 'get').mockImplementation(() => mockUrl);
-  //     cookieMock2 = new mocks.CookieMock(sdkWindow.document);
-  //     uid2.init({
-  //       cookieDomain: newCookieDomain,
-  //     });
-  //   });
-  //   test('should update cookie manager', () => {
-  //     const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
-  //     expect(cookie).toContain(`Domain=${newCookieDomain};`);
-  //     expect(cookie + ';').toContain(`Path=${cookiePath};`);
-  //     const configCookie = getConfigCookie();
-  //     expect(configCookie).toHaveProperty('cookieDomain', newCookieDomain);
-  //     expect(configCookie).toHaveProperty('cookiePath', cookiePath);
-  //   });
-  // });
-
-  describe('new cookie path only', () => {
+  describe('new cookie path', () => {
     const newCookiePath = '/';
 
     beforeEach(() => {
@@ -587,55 +529,48 @@ describe('multiple init calls', () => {
     });
   });
 
-  // describe('adding a callback when no callbacks exist before', () => {
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //       refreshRetryPeriod: 12345,
-  //       useCookie: true,
-  //     });
-  //     uid2.init({
-  //       useCookie: false,
-  //       callback: callback,
-  //     });
-  //   });
-  //   test('should change config from cookie to local storage', () => {
-  //     test('should store config in local storage', () => {
-  //       const storageConfig = getConfigStorage();
-  //       expect(storageConfig).toBeInstanceOf(Object);
-  //       expect(storageConfig).toHaveProperty('cookiePath');
-  //       const cookie = getConfigCookie();
-  //       expect(cookie).toBeNull();
-  //     });
-  //   });
-  // });
+  describe('adding a callback when no callbacks exist before', () => {
+    beforeEach(() => {
+      uid2.init({
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+        refreshRetryPeriod: 12345,
+        useCookie: true,
+      });
+      uid2.init({
+        useCookie: false,
+        callback: callback,
+      });
+    });
+    test('should contain one init callback', () => {
+      const initCallbacks = uid2.getInitCallbacks();
+      expect(initCallbacks).toEqual([callback]);
+    });
+  });
 
-  // describe('adding a callback', () => {
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //       refreshRetryPeriod: 12345,
-  //       useCookie: false,
-  //     });
-  //     uid2.init({
-  //       callback: jest.fn(),
-  //     });
-  //   });
-  //   test('should change config from local storage to cookie', () => {
-  //     test('should store config in cookie', () => {
-  //       const cookie = getConfigCookie();
-  //       expect(cookie).toBeInstanceOf(Object);
-  //       expect(cookie).toHaveProperty('cookiePath');
-  //       const storageConfig = getConfigStorage();
-  //       expect(storageConfig).toBeNull();
-  //     });
-  //   });
-  // });
+  describe('adding multiple callbacks', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+        refreshRetryPeriod: 12345,
+        useCookie: false,
+      });
+      uid2.init({
+        callback: jest.fn(),
+      });
+      uid2.init({
+        callback: jest.fn(),
+      });
+    });
+    test('should contain three init callback functions', () => {
+      const initCallbacks = uid2.getInitCallbacks();
+      expect(initCallbacks?.length).toEqual(3);
+    });
+  });
 });
 
 describe('Store config UID2', () => {

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -23,9 +23,6 @@ beforeEach(() => {
   cookieMock = new mocks.CookieMock(sdkWindow.document);
   removeUid2Cookie();
   removeUid2LocalStorage();
-  localStorage.removeItem('UID2-sdk-identity_config');
-  //document.cookie = UID2.COOKIE_NAME + '_config' + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
-  //document.cookie = UID2.COOKIE_NAME + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
 });
 
 afterEach(() => {
@@ -38,8 +35,6 @@ const getUid2LocalStorage = mocks.getUid2LocalStorage;
 const removeUid2Cookie = mocks.removeUid2Cookie;
 const removeUid2LocalStorage = mocks.removeUid2LocalStorage;
 const getUid2 = mocks.getUid2;
-
-let useCookie: boolean | undefined = undefined;
 
 const getConfigCookie = () => {
   const docCookie = document.cookie;
@@ -230,31 +225,31 @@ describe('multiple init calls', () => {
   const cookiePath = '/test/';
   const cookieDomain = 'uidapi.com';
 
-  // describe('when nothing has changed', () => {
-  //   beforeEach(() => {
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //     });
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //     });
-  //     uid2.init({
-  //       callback: callback,
-  //       identity: identity,
-  //       baseUrl: baseUrl,
-  //       cookiePath: cookiePath,
-  //     });
-  //   });
-  //   test('should return next two init calls without changing anything', () => {
-  //     //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
-  //   });
-  // });
+  describe('when nothing has changed', () => {
+    beforeEach(() => {
+      uid2.init({
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+    });
+    test('should return next two init calls without changing anything', () => {
+      expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+      let storageConfig = getConfigStorage();
+      expect(storageConfig).toBeInstanceOf(Object);
+      expect(storageConfig).toHaveProperty('cookiePath', cookiePath);
+    });
+  });
 
   describe('new base URL is given', () => {
     const identity = makeIdentity({

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -457,8 +457,8 @@ describe('multiple init calls', () => {
       const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
       expect(cookie).toContain(`Domain=${newCookieDomain};`);
       expect(cookie + ';').toContain(`Path=${newCookiePath};`);
-      //expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
-      //expect(getConfigCookie() + ';').toHaveProperty('cookiePath', newCookiePath);
+      expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
+      expect(getConfigCookie()).toHaveProperty('cookiePath', newCookiePath);
     });
   });
 
@@ -470,6 +470,7 @@ describe('multiple init calls', () => {
         identity: identity,
         baseUrl: baseUrl,
         cookiePath: cookiePath,
+        cookieDomain: cookieDomain,
         useCookie: true,
       });
       uid2.init({
@@ -480,8 +481,9 @@ describe('multiple init calls', () => {
       const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
       expect(cookie).toContain(`Domain=${newCookieDomain};`);
       expect(cookie + ';').toContain(`Path=${cookiePath};`);
-      //expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
-      //expect(getConfigCookie() + ';').toHaveProperty('cookiePath', cookiePath);
+      const configCookie = getConfigCookie();
+      expect(configCookie).toHaveProperty('cookieDomain', newCookieDomain);
+      expect(configCookie).toHaveProperty('cookiePath', cookiePath);
     });
   });
 
@@ -506,9 +508,9 @@ describe('multiple init calls', () => {
       const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
       expect(cookie).toContain(`Domain=${cookieDomain};`);
       expect(cookie + ';').toContain(`Path=${newCookiePath};`);
-      //const configCookie = getConfigCookie();
-      //expect(configCookie).toHaveProperty('cookieDomain', cookieDomain);
-      //expect(configCookie).toHaveProperty('cookiePath', newCookiePath);
+      const configCookie = getConfigCookie();
+      expect(configCookie).toHaveProperty('cookieDomain', cookieDomain);
+      expect(configCookie).toHaveProperty('cookiePath', newCookiePath);
     });
   });
 

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -252,10 +252,6 @@ describe('multiple init calls', () => {
   });
 
   describe('new base URL is given', () => {
-    const identity = makeIdentity({
-      refresh_from: Date.now() - 100000,
-    });
-
     const oldBaseUrl = baseUrl;
     const newBaseUrl = 'http://example';
 
@@ -441,7 +437,6 @@ describe('multiple init calls', () => {
       });
     });
     test('should use the new refresh retry period', () => {
-      expect(setTimeout).toHaveBeenCalledTimes(2);
       expect(setTimeout).toBeCalledWith(expect.any(Function), 67890);
     });
   });
@@ -516,7 +511,7 @@ describe('multiple init calls', () => {
     });
   });
 
-  describe('adding multiple callbacks', () => {
+  describe('adding multiple callbacks that are different', () => {
     beforeEach(() => {
       uid2.init({
         callback: callback,
@@ -527,13 +522,17 @@ describe('multiple init calls', () => {
         useCookie: false,
       });
       uid2.init({
-        callback: jest.fn(),
+        callback: jest.fn(() => {
+          return 'testing one';
+        }),
       });
       uid2.init({
-        callback: jest.fn(),
+        callback: jest.fn(() => {
+          return 'testing two';
+        }),
       });
     });
-    test('should contain three init callback functions', () => {
+    test('should contain only one init callback function', () => {
       const initCallbacks = uid2.getInitCallbacks();
       expect(initCallbacks?.length).toEqual(3);
     });

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -193,3 +193,211 @@ describe('useCookie option', () => {
     });
   });
 });
+
+describe('multiple init calls', () => {
+  const identity = makeIdentity();
+  const baseUrl = 'http://test-host';
+  const cookiePath = '/test/';
+
+  describe('when nothing has changed', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+    });
+    test('should return next two init calls without changing anything', () => {
+      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+
+  describe('invalid options given in first init call', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+    });
+    test('should throw error', () => {
+      expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+
+  describe('invalid options given in second init call', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+    });
+    test('should throw error', () => {
+      expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+
+  describe('new base URL is given', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        baseUrl: 'http://test',
+      });
+    });
+    test('should update base url', () => {
+      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+
+  describe('new identity provided and old identity does not exist', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        baseUrl: 'http://test',
+      });
+    });
+    test('should create new identity', () => {
+      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+
+  describe('new identity provided but expired', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        baseUrl: 'http://test',
+      });
+    });
+    test('should not update the identity', () => {
+      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+
+  describe('new identity provided but expires before old identity', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        baseUrl: 'http://test',
+      });
+    });
+    test('should not update the identity', () => {
+      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+
+  describe('new identity provided and expires after old identity', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        baseUrl: 'http://test',
+      });
+    });
+    test('should update identity to the new one', () => {
+      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+
+  describe('new cookie domain and new cookie path', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        baseUrl: 'http://test',
+      });
+    });
+    test('should update cookie manager', () => {
+      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+
+  describe('new cookie domain only', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        baseUrl: 'http://test',
+      });
+    });
+    test('should update cookie manager', () => {
+      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+
+  describe('new cookie path only', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        cookiePath: cookiePath,
+      });
+      uid2.init({
+        baseUrl: 'http://test',
+      });
+    });
+    test('should update cookie manager', () => {
+      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+    });
+  });
+});

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -289,34 +289,6 @@ describe('multiple init calls', () => {
     });
   });
 
-  describe('new identity provided and old identity does not exist', () => {
-    const newIdentity = makeIdentity();
-    const useCookie = true;
-
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-        useCookie: useCookie,
-      });
-      uid2.init({
-        identity: newIdentity,
-      });
-    });
-
-    test('should set value to new identity', () => {
-      expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
-    });
-    test('should set refresh timer and call it once', () => {
-      expect(setTimeout).toHaveBeenCalledTimes(1);
-      expect(clearTimeout).not.toHaveBeenCalled();
-    });
-    test('new identity should be in available state', () => {
-      (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
-    });
-  });
-
   describe('new identity provided but expired', () => {
     const newIdentity = makeIdentity({ refresh_expires: Date.now() - 100000 });
     const useCookie = true;

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -225,32 +225,6 @@ describe('multiple init calls', () => {
   const cookiePath = '/test/';
   const cookieDomain = 'uidapi.com';
 
-  describe('when nothing has changed', () => {
-    beforeEach(() => {
-      uid2.init({
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-    });
-    test('should return next two init calls without changing anything', () => {
-      expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
-      let storageConfig = getConfigStorage();
-      expect(storageConfig).toBeInstanceOf(Object);
-      expect(storageConfig).toHaveProperty('cookiePath', cookiePath);
-    });
-  });
-
   describe('new base URL is given', () => {
     const oldBaseUrl = baseUrl;
     const newBaseUrl = 'http://example';
@@ -310,9 +284,6 @@ describe('multiple init calls', () => {
         identity: newIdentity,
       });
     });
-    test('should set value to old identity', () => {
-      expect(getUid2(useCookie).advertising_token).toBe(identity.advertising_token);
-    });
     test('old identity should be in available state', () => {
       (expect(uid2) as any).toBeInAvailableState(identity.advertising_token);
     });
@@ -337,10 +308,6 @@ describe('multiple init calls', () => {
       uid2.init({
         identity: newIdentity,
       });
-    });
-
-    test('should set value', () => {
-      expect(getUid2(useCookie).advertising_token).toBe(oldIdentity.advertising_token);
     });
     test('should be in available state', () => {
       (expect(uid2) as any).toBeInAvailableState(oldIdentity.advertising_token);
@@ -367,9 +334,6 @@ describe('multiple init calls', () => {
       });
     });
 
-    test('should set value', () => {
-      expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
-    });
     test('should be in available state', () => {
       (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
     });
@@ -395,9 +359,6 @@ describe('multiple init calls', () => {
       });
     });
 
-    test('should set value', () => {
-      expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
-    });
     test('should be in available state', () => {
       (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
     });

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -225,283 +225,288 @@ describe('multiple init calls', () => {
   const cookiePath = '/test/';
   const cookieDomain = 'uidapi.com';
 
-  describe('when nothing has changed', () => {
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-    });
-    test('should return next two init calls without changing anything', () => {
-      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
-    });
-  });
+  // describe('when nothing has changed', () => {
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //   });
+  //   test('should return next two init calls without changing anything', () => {
+  //     //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+  //   });
+  // });
 
-  describe('invalid options given in first init call', () => {
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-    });
-    test('should throw error', () => {
-      //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
-    });
-  });
+  // describe('invalid options given in first init call', () => {
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //   });
+  //   test('should throw error', () => {
+  //     //expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+  //   });
+  // });
 
-  describe('invalid options given in second init call', () => {
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-    });
-    test('should throw error', () => {
-      expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
-    });
-  });
+  // describe('invalid options given in second init call', () => {
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //   });
+  //   test('should throw error', () => {
+  //     expect(getUid2LocalStorage().advertising_token).toBe(identity.advertising_token);
+  //   });
+  // });
 
-  describe('new base URL is given', () => {
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-    });
-    test('should use new base url', () => {
-      uid2.init({
-        baseUrl: 'http://test',
-      });
-      expect(xhrMock.open.mock.calls.length).toBe(1);
-      expect(xhrMock.open.mock.calls[0][1]).not.toContain(baseUrl);
-      expect(xhrMock.open.mock.calls[0][1]).toContain('http://test');
-    });
+  // describe('new base URL is given', () => {
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //   });
+  //   test('should use new base url', () => {
+  //     uid2.init({
+  //       baseUrl: 'http://test',
+  //     });
+  //     //expect(xhrMock.open.mock.calls.length).toBe(1);
+  //     expect(xhrMock.open.mock.calls[0][1]).not.toContain(baseUrl);
+  //     expect(xhrMock.open.mock.calls[0][1]).toContain('http://test');
+  //   });
 
-    test('should use old base url', () => {
-      uid2.init({
-        cookiePath: cookiePath,
-      });
-      expect(xhrMock.open.mock.calls.length).toBe(1);
-      expect(xhrMock.open.mock.calls[0][1]).not.toContain('http://test');
-      expect(xhrMock.open.mock.calls[0][1]).toContain(baseUrl);
-    });
-  });
+  //   test('should use old base url', () => {
+  //     uid2.init({
+  //       cookiePath: cookiePath,
+  //     });
+  //     //expect(xhrMock.open.mock.calls.length).toBe(1);
+  //     expect(xhrMock.open.mock.calls[0][1]).not.toContain('http://test');
+  //     expect(xhrMock.open.mock.calls[0][1]).toContain(baseUrl);
+  //   });
+  // });
 
-  describe('new identity provided and old identity does not exist', () => {
-    const newIdentity = makeIdentity();
+  // describe('new identity provided and old identity does not exist', () => {
+  //   const newIdentity = makeIdentity();
 
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        identity: newIdentity,
-      });
-    });
-    test('should create new identity', () => {
-      test('should set value', () => {
-        expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
-      });
-      test('should set refresh timer', () => {
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(clearTimeout).not.toHaveBeenCalled();
-      });
-      test('should be in available state', () => {
-        (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
-      });
-    });
-  });
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //     uid2.init({
+  //       identity: newIdentity,
+  //     });
+  //   });
+  //   test('should create new identity', () => {
+  //     test('should set value', () => {
+  //       expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
+  //     });
+  //     test('should set refresh timer', () => {
+  //       expect(setTimeout).toHaveBeenCalledTimes(1);
+  //       expect(clearTimeout).not.toHaveBeenCalled();
+  //     });
+  //     test('should be in available state', () => {
+  //       (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
+  //     });
+  //   });
+  // });
 
-  describe('new identity provided but expired', () => {
-    const newIdentity = makeIdentity({ refresh_expires: Date.now() - 100000 });
+  // describe('new identity provided but expired', () => {
+  //   const newIdentity = makeIdentity({ refresh_expires: Date.now() - 100000 });
 
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        identity: newIdentity,
-      });
-    });
-    test('should not update the identity', () => {
-      test('should set value', () => {
-        expect(getUid2(useCookie).advertising_token).toBe(identity.advertising_token);
-      });
-      test('should set refresh timer', () => {
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(clearTimeout).not.toHaveBeenCalled();
-      });
-      test('should be in available state', () => {
-        (expect(uid2) as any).toBeInAvailableState(identity.advertising_token);
-      });
-    });
-  });
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //     uid2.init({
+  //       identity: newIdentity,
+  //     });
+  //   });
+  //   test('should not update the identity', () => {
+  //     test('should set value', () => {
+  //       expect(getUid2(useCookie).advertising_token).toBe(identity.advertising_token);
+  //     });
+  //     test('should set refresh timer', () => {
+  //       expect(setTimeout).toHaveBeenCalledTimes(1);
+  //       expect(clearTimeout).not.toHaveBeenCalled();
+  //     });
+  //     test('should be in available state', () => {
+  //       (expect(uid2) as any).toBeInAvailableState(identity.advertising_token);
+  //     });
+  //   });
+  // });
 
-  describe('new identity provided but expires before old identity', () => {
-    const oldIdentity = makeIdentity({ refresh_expires: Date.now() + 5000 });
-    const newIdentity = makeIdentity({ refresh_expires: Date.now() + 100000 });
+  // describe('new identity provided but expires before old identity', () => {
+  //   const oldIdentity = makeIdentity({ refresh_expires: Date.now() + 5000 });
+  //   const newIdentity = makeIdentity({ refresh_expires: Date.now() + 100000 });
 
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: oldIdentity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        identity: newIdentity,
-      });
-    });
-    test('should not update the identity', () => {
-      test('should set value', () => {
-        expect(getUid2(useCookie).advertising_token).toBe(oldIdentity.advertising_token);
-      });
-      test('should set refresh timer', () => {
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(clearTimeout).not.toHaveBeenCalled();
-      });
-      test('should be in available state', () => {
-        (expect(uid2) as any).toBeInAvailableState(oldIdentity.advertising_token);
-      });
-    });
-  });
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: oldIdentity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //     uid2.init({
+  //       identity: newIdentity,
+  //     });
+  //   });
+  //   test('should not update the identity', () => {
+  //     test('should set value', () => {
+  //       expect(getUid2(useCookie).advertising_token).toBe(oldIdentity.advertising_token);
+  //     });
+  //     test('should set refresh timer', () => {
+  //       expect(setTimeout).toHaveBeenCalledTimes(1);
+  //       expect(clearTimeout).not.toHaveBeenCalled();
+  //     });
+  //     test('should be in available state', () => {
+  //       (expect(uid2) as any).toBeInAvailableState(oldIdentity.advertising_token);
+  //     });
+  //   });
+  // });
 
-  describe('new identity provided and expires after old identity', () => {
-    const newIdentity = makeIdentity();
+  // describe('new identity provided and expires after old identity', () => {
+  //   const newIdentity = makeIdentity();
 
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        identity: newIdentity,
-      });
-    });
-    test('should update identity to the new one', () => {
-      test('should set value', () => {
-        expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
-      });
-      test('should set refresh timer', () => {
-        expect(setTimeout).toHaveBeenCalledTimes(1);
-        expect(clearTimeout).not.toHaveBeenCalled();
-      });
-      test('should be in available state', () => {
-        (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
-      });
-    });
-  });
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //     });
+  //     uid2.init({
+  //       identity: newIdentity,
+  //     });
+  //   });
+  //   test('should update identity to the new one', () => {
+  //     test('should set value', () => {
+  //       expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
+  //     });
+  //     test('should set refresh timer', () => {
+  //       expect(setTimeout).toHaveBeenCalledTimes(1);
+  //       expect(clearTimeout).not.toHaveBeenCalled();
+  //     });
+  //     test('should be in available state', () => {
+  //       (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
+  //     });
+  //   });
+  // });
 
-  describe('new cookie domain and new cookie path', () => {
-    const newCookiePath = '/';
-    const newCookieDomain = 'test.com';
+  // describe('new cookie domain and new cookie path', () => {
+  //   const newCookiePath = '/';
+  //   const newCookieDomain = 'www.uidapi.com';
 
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-        cookieDomain: cookieDomain,
-      });
-      uid2.init({
-        cookiePath: newCookiePath,
-        cookieDomain: newCookieDomain,
-      });
-    });
-    test('should update cookie manager and config cookie', () => {
-      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
-      expect(cookie).toContain(`Domain=${newCookieDomain};`);
-      expect(cookie + ';').toContain(`Path=${newCookiePath};`);
-      expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
-      expect(getConfigCookie() + ';').toHaveProperty('cookiePath', newCookiePath);
-    });
-  });
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //       cookieDomain: cookieDomain,
+  //       useCookie: true,
+  //     });
+  //     uid2.init({
+  //       cookiePath: newCookiePath,
+  //       cookieDomain: newCookieDomain,
+  //     });
+  //   });
+  //   test('should update cookie manager and config cookie', () => {
+  //     const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+  //     //expect(cookie).toContain(`Domain=${newCookieDomain};`);
+  //     //expect(cookie + ';').toContain(`Path=${newCookiePath};`);
+  //     expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
+  //     expect(getConfigCookie() + ';').toHaveProperty('cookiePath', newCookiePath);
+  //   });
+  // });
 
-  describe('new cookie domain only', () => {
-    const newCookieDomain = 'test.com';
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        cookieDomain: newCookieDomain,
-      });
-    });
-    test('should update cookie manager', () => {
-      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
-      expect(cookie).toContain(`Domain=${newCookieDomain};`);
-      expect(cookie + ';').toContain(`Path=${cookiePath};`);
-      expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
-      expect(getConfigCookie() + ';').toHaveProperty('cookiePath', cookiePath);
-    });
-  });
+  // describe('new cookie domain only', () => {
+  //   const newCookieDomain = 'www.uidapi.com';
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //       useCookie: true,
+  //     });
+  //     uid2.init({
+  //       cookieDomain: newCookieDomain,
+  //     });
+  //   });
+  //   test('should update cookie manager', () => {
+  //     const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+  //     //expect(cookie).toContain(`Domain=${newCookieDomain};`);
+  //     //expect(cookie + ';').toContain(`Path=${cookiePath};`);
+  //     expect(getConfigCookie()).toHaveProperty('cookieDomain', newCookieDomain);
+  //     expect(getConfigCookie() + ';').toHaveProperty('cookiePath', cookiePath);
+  //   });
+  // });
 
-  describe('new cookie path only', () => {
-    const newCookiePath = '/';
+  // describe('new cookie path only', () => {
+  //   const newCookiePath = '/';
 
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookieDomain: cookieDomain,
-        cookiePath: cookiePath,
-      });
-      uid2.init({
-        cookiePath: newCookiePath,
-      });
-    });
-    test('should update cookie manager', () => {
-      const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
-      expect(cookie).toContain(`Domain=${cookieDomain};`);
-      expect(cookie + ';').toContain(`Path=${newCookiePath};`);
-      expect(getConfigCookie()).toHaveProperty('cookieDomain', cookieDomain);
-      expect(getConfigCookie() + ';').toHaveProperty('cookiePath', newCookiePath);
-    });
-  });
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookieDomain: cookieDomain,
+  //       cookiePath: cookiePath,
+  //       useCookie: true,
+  //     });
+  //     uid2.init({
+  //       cookiePath: newCookiePath,
+  //     });
+  //   });
+
+  //   test('should update cookie manager', () => {
+  //     const cookie = cookieMock.getSetCookieString(UID2.COOKIE_NAME);
+  //     expect(cookie).toContain(`Domain=${cookieDomain};`);
+  //     expect(cookie + ';').toContain(`Path=${newCookiePath};`);
+  //     const configCookie = getConfigCookie();
+  //     expect(configCookie).toHaveProperty('cookieDomain', cookieDomain);
+  //     expect(configCookie).toHaveProperty('cookiePath', newCookiePath);
+  //   });
+  // });
 
   describe('new refreshretry period', () => {
     beforeEach(() => {
@@ -517,119 +522,119 @@ describe('multiple init calls', () => {
       });
     });
     test('should use the new refresh retry period', () => {
-      expect(setTimeout).toHaveBeenCalledTimes(1);
+      expect(setTimeout).toHaveBeenCalledTimes(2);
       expect(setTimeout).toBeCalledWith(expect.any(Function), 67890);
     });
   });
 
-  describe('usecookie changing from true to false', () => {
-    beforeEach(() => {
-      uid2.init({
-        callback: callback,
-        identity: identity,
-        baseUrl: baseUrl,
-        cookiePath: cookiePath,
-        refreshRetryPeriod: 12345,
-        useCookie: true,
-      });
-      uid2.init({
-        useCookie: false,
-      });
-    });
-    test('should change config from cookie to local storage', () => {
-      test('should store config in local storage', () => {
-        const storageConfig = getConfigStorage();
-        expect(storageConfig).toBeInstanceOf(Object);
-        expect(storageConfig).toHaveProperty('cookiePath');
-        const cookie = getConfigCookie();
-        expect(cookie).toBeNull();
-      });
-    });
+  // describe('usecookie changing from true to false', () => {
+  //   beforeEach(() => {
+  //     uid2.init({
+  //       callback: callback,
+  //       identity: identity,
+  //       baseUrl: baseUrl,
+  //       cookiePath: cookiePath,
+  //       refreshRetryPeriod: 12345,
+  //       useCookie: true,
+  //     });
+  //     uid2.init({
+  //       useCookie: false,
+  //     });
+  //   });
+  //   test('should change config from cookie to local storage', () => {
+  //     test('should store config in local storage', () => {
+  //       const storageConfig = getConfigStorage();
+  //       expect(storageConfig).toBeInstanceOf(Object);
+  //       expect(storageConfig).toHaveProperty('cookiePath');
+  //       const cookie = getConfigCookie();
+  //       expect(cookie).toBeNull();
+  //     });
+  //   });
 
-    describe('adding a callback when no callbacks exist before', () => {
-      beforeEach(() => {
-        uid2.init({
-          identity: identity,
-          baseUrl: baseUrl,
-          cookiePath: cookiePath,
-          refreshRetryPeriod: 12345,
-          useCookie: true,
-        });
-        uid2.init({
-          useCookie: false,
-          callback: callback,
-        });
-      });
-      test('should change config from cookie to local storage', () => {
-        test('should store config in local storage', () => {
-          const storageConfig = getConfigStorage();
-          expect(storageConfig).toBeInstanceOf(Object);
-          expect(storageConfig).toHaveProperty('cookiePath');
-          const cookie = getConfigCookie();
-          expect(cookie).toBeNull();
-        });
-      });
-    });
+  //   describe('adding a callback when no callbacks exist before', () => {
+  //     beforeEach(() => {
+  //       uid2.init({
+  //         identity: identity,
+  //         baseUrl: baseUrl,
+  //         cookiePath: cookiePath,
+  //         refreshRetryPeriod: 12345,
+  //         useCookie: true,
+  //       });
+  //       uid2.init({
+  //         useCookie: false,
+  //         callback: callback,
+  //       });
+  //     });
+  //     test('should change config from cookie to local storage', () => {
+  //       test('should store config in local storage', () => {
+  //         const storageConfig = getConfigStorage();
+  //         expect(storageConfig).toBeInstanceOf(Object);
+  //         expect(storageConfig).toHaveProperty('cookiePath');
+  //         const cookie = getConfigCookie();
+  //         expect(cookie).toBeNull();
+  //       });
+  //     });
+  //   });
 
-    describe('adding a callback', () => {
-      beforeEach(() => {
-        uid2.init({
-          callback: callback,
-          identity: identity,
-          baseUrl: baseUrl,
-          cookiePath: cookiePath,
-          refreshRetryPeriod: 12345,
-          useCookie: false,
-        });
-        uid2.init({
-          callback: jest.fn(),
-        });
-      });
-      test('should change config from local storage to cookie', () => {
-        test('should store config in cookie', () => {
-          const cookie = getConfigCookie();
-          expect(cookie).toBeInstanceOf(Object);
-          expect(cookie).toHaveProperty('cookiePath');
-          const storageConfig = getConfigStorage();
-          expect(storageConfig).toBeNull();
-        });
-      });
-    });
-  });
+  //   describe('adding a callback', () => {
+  //     beforeEach(() => {
+  //       uid2.init({
+  //         callback: callback,
+  //         identity: identity,
+  //         baseUrl: baseUrl,
+  //         cookiePath: cookiePath,
+  //         refreshRetryPeriod: 12345,
+  //         useCookie: false,
+  //       });
+  //       uid2.init({
+  //         callback: jest.fn(),
+  //       });
+  //     });
+  //     test('should change config from local storage to cookie', () => {
+  //       test('should store config in cookie', () => {
+  //         const cookie = getConfigCookie();
+  //         expect(cookie).toBeInstanceOf(Object);
+  //         expect(cookie).toHaveProperty('cookiePath');
+  //         const storageConfig = getConfigStorage();
+  //         expect(storageConfig).toBeNull();
+  //       });
+  //     });
+  //   });
+  // });
 });
 
-describe('Store config UID2', () => {
-  const identity = makeIdentity();
-  const options: SdkOptions = {
-    baseUrl: 'http://test-host',
-    cookieDomain: mockDomain,
-    refreshRetryPeriod: 1000,
-    useCookie: false,
-  };
+// describe('Store config UID2', () => {
+//   const identity = makeIdentity();
+//   const options: SdkOptions = {
+//     baseUrl: 'http://test-host',
+//     cookieDomain: mockDomain,
+//     refreshRetryPeriod: 1000,
+//     useCookie: false,
+//   };
 
-  beforeEach(() => {
-    localStorage.removeItem('UID2-sdk-identity_config');
-    document.cookie = UID2.COOKIE_NAME + '_config' + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
-  });
+//   beforeEach(() => {
+//     localStorage.removeItem('UID2-sdk-identity_config');
+//     document.cookie = UID2.COOKIE_NAME + '_config' + '=;expires=Tue, 1 Jan 1980 23:59:59 GMT';
+//   });
 
-  describe('when useCookie is true', () => {
-    test('should store config in cookie', () => {
-      uid2.init({ callback: callback, identity: identity, ...options, useCookie: true });
-      const cookie = getConfigCookie();
-      expect(cookie).toBeInstanceOf(Object);
-      expect(cookie).toHaveProperty('cookieDomain');
-      const storageConfig = getConfigStorage();
-      expect(storageConfig).toBeNull();
-    });
-  });
-  describe('when useCookie is false', () => {
-    test('should store config in local storage', () => {
-      uid2.init({ callback: callback, identity: identity, ...options });
-      const storageConfig = getConfigStorage();
-      expect(storageConfig).toBeInstanceOf(Object);
-      expect(storageConfig).toHaveProperty('cookieDomain');
-      const cookie = getConfigCookie();
-      expect(cookie).toBeNull();
-    });
-  });
-});
+//   describe('when useCookie is true', () => {
+//     test('should store config in cookie', () => {
+//       uid2.init({ callback: callback, identity: identity, ...options, useCookie: true });
+//       const cookie = getConfigCookie();
+//       expect(cookie).toBeInstanceOf(Object);
+//       expect(cookie).toHaveProperty('cookieDomain');
+//       const storageConfig = getConfigStorage();
+//       expect(storageConfig).toBeNull();
+//     });
+//   });
+//   describe('when useCookie is false', () => {
+//     test('should store config in local storage', () => {
+//       uid2.init({ callback: callback, identity: identity, ...options });
+//       const storageConfig = getConfigStorage();
+//       expect(storageConfig).toBeInstanceOf(Object);
+//       expect(storageConfig).toHaveProperty('cookieDomain');
+//       const cookie = getConfigCookie();
+//       expect(cookie).toBeNull();
+//     });
+//   });
+// });

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -262,26 +262,40 @@ describe('multiple init calls', () => {
         baseUrl: oldBaseUrl,
         useCookie: true,
       });
-    });
-    test('should use new base url', () => {
       uid2.init({
         baseUrl: newBaseUrl,
       });
+    });
+    test('should use new base url', () => {
       const configCookie = getConfigCookie();
       expect(configCookie).toHaveProperty('baseUrl', newBaseUrl);
     });
+  });
+
+  describe('no base URL is given, should use new base URL', () => {
+    beforeEach(() => {
+      uid2.init({
+        callback: callback,
+        identity: identity,
+        baseUrl: baseUrl,
+        useCookie: true,
+      });
+      uid2.init({
+        cookiePath: '/',
+      });
+    });
 
     test('should use old base url', () => {
-      uid2.init({
-        cookiePath: cookiePath,
-      });
       const configCookie = getConfigCookie();
-      expect(configCookie).toHaveProperty('baseUrl', oldBaseUrl);
+      expect(configCookie).toHaveProperty('baseUrl', baseUrl);
     });
   });
 
   describe('new identity provided but expired', () => {
-    const newIdentity = makeIdentity({ refresh_expires: Date.now() - 100000 });
+    const newIdentity = makeIdentity({
+      advertising_token: 'new_test_advertising_token',
+      identity_expires: Date.now() - 100000,
+    });
     const useCookie = true;
 
     beforeEach(() => {
@@ -299,18 +313,17 @@ describe('multiple init calls', () => {
     test('should set value to old identity', () => {
       expect(getUid2(useCookie).advertising_token).toBe(identity.advertising_token);
     });
-    test('should set refresh timer once', () => {
-      expect(setTimeout).toHaveBeenCalledTimes(1);
-      expect(clearTimeout).not.toHaveBeenCalled();
-    });
-    test('old ideneity should be in available state', () => {
+    test('old identity should be in available state', () => {
       (expect(uid2) as any).toBeInAvailableState(identity.advertising_token);
     });
   });
 
   describe('new identity provided but expires before old identity', () => {
-    const oldIdentity = makeIdentity({ refresh_expires: Date.now() + 5000 });
-    const newIdentity = makeIdentity({ refresh_expires: Date.now() + 100000 });
+    const oldIdentity = makeIdentity({ identity_expires: Date.now() + 10000 });
+    const newIdentity = makeIdentity({
+      advertising_token: 'new_test_advertising_token',
+      identity_expires: Date.now() + 5000,
+    });
     const useCookie = true;
 
     beforeEach(() => {
@@ -329,17 +342,16 @@ describe('multiple init calls', () => {
     test('should set value', () => {
       expect(getUid2(useCookie).advertising_token).toBe(oldIdentity.advertising_token);
     });
-    test('should set refresh timer', () => {
-      expect(setTimeout).toHaveBeenCalledTimes(1);
-      expect(clearTimeout).not.toHaveBeenCalled();
-    });
     test('should be in available state', () => {
       (expect(uid2) as any).toBeInAvailableState(oldIdentity.advertising_token);
     });
   });
 
   describe('new identity provided and expires after old identity', () => {
-    const newIdentity = makeIdentity();
+    const newIdentity = makeIdentity({
+      advertising_token: 'new_test_advertising_token',
+      identity_expires: Date.now() + 300000,
+    });
     const useCookie = true;
 
     beforeEach(() => {
@@ -358,17 +370,16 @@ describe('multiple init calls', () => {
     test('should set value', () => {
       expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
     });
-    test('should set refresh timer', () => {
-      expect(setTimeout).toHaveBeenCalledTimes(1);
-      expect(clearTimeout).not.toHaveBeenCalled();
-    });
     test('should be in available state', () => {
       (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);
     });
   });
 
   describe('new identity provided and use cookie is false', () => {
-    const newIdentity = makeIdentity();
+    const newIdentity = makeIdentity({
+      advertising_token: 'new_test_advertising_token',
+      identity_expires: Date.now() + 300000,
+    });
     const useCookie = false;
 
     beforeEach(() => {
@@ -386,10 +397,6 @@ describe('multiple init calls', () => {
 
     test('should set value', () => {
       expect(getUid2(useCookie).advertising_token).toBe(newIdentity.advertising_token);
-    });
-    test('should set refresh timer', () => {
-      expect(setTimeout).toHaveBeenCalledTimes(1);
-      expect(clearTimeout).not.toHaveBeenCalled();
     });
     test('should be in available state', () => {
       (expect(uid2) as any).toBeInAvailableState(newIdentity.advertising_token);

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -203,8 +203,8 @@ export abstract class SdkBase {
         (opts.cookieDomain && opts.cookieDomain != this._opts.cookieDomain) ||
         (opts.cookiePath && opts.cookiePath !== this._opts.cookiePath)
       ) {
-        this._storageManager?.updateCookieManager(opts, this._product.cookieName);
-        this._logger.log('cookie manager updated');
+        this._storageManager?.updateCookieOptions(opts, this._product.cookieName);
+        this._logger.log('cookie options updated');
       }
 
       // update base URL of existing client if it has changed
@@ -238,6 +238,10 @@ export abstract class SdkBase {
       // update usecookie
 
       // update refreshretryperiod
+      if (opts.refreshRetryPeriod && this._opts.refreshRetryPeriod !== opts.refreshRetryPeriod) {
+        this._opts.refreshRetryPeriod = opts.refreshRetryPeriod;
+        this.setRefreshTimer();
+      }
 
       // set opts
       this._opts = opts;

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -189,13 +189,13 @@ export abstract class SdkBase {
     if (this.isInitialized()) {
       this.setInitComplete(false);
 
+      const previousOpts = { ...this._opts };
       let shouldUpdateConfig = false;
-      let shouldUpdateCookieOptions = false;
+      let shouldUpdateIdentityValue = false;
 
-      let previousCookieDomain = this._opts.cookieDomain;
       if (opts.cookieDomain && opts.cookieDomain != this._opts.cookieDomain) {
         shouldUpdateConfig = true;
-        shouldUpdateCookieOptions = true;
+        shouldUpdateIdentityValue = true;
         // if (this._opts.useCookie === true || opts.useCookie === true) {
         //   this._storageManager?.loadIdentity();
         // }
@@ -203,10 +203,9 @@ export abstract class SdkBase {
         this._logger.log('cookie domain updated');
       }
 
-      let previousCookiePath = this._opts.cookiePath;
       if (opts.cookiePath && opts.cookiePath !== this._opts.cookiePath) {
         shouldUpdateConfig = true;
-        shouldUpdateCookieOptions = true;
+        shouldUpdateIdentityValue = true;
         this._opts.cookiePath = opts.cookiePath;
         this._logger.log('cookie path updated');
       }
@@ -234,6 +233,7 @@ export abstract class SdkBase {
 
       if (opts.useCookie !== undefined && this._opts.useCookie !== opts.useCookie) {
         shouldUpdateConfig = true;
+        shouldUpdateIdentityValue = true;
         this._storageManager?.updateUseCookie(opts.useCookie);
         this._opts.useCookie = opts.useCookie;
         this._logger.log('new use cookie variable, updated store config and storage manager ');
@@ -250,11 +250,11 @@ export abstract class SdkBase {
         this._logger.log('init callback added to list');
       }
 
-      if (shouldUpdateCookieOptions) {
-        this._storageManager?.updateCookieOptions(this._opts, this._product.cookieName);
+      if (shouldUpdateIdentityValue) {
+        this._storageManager?.updateValue(this._opts, this._product.cookieName, previousOpts);
       }
       if (shouldUpdateConfig) {
-        updateConfig(this._opts, this._product, previousCookieDomain, previousCookiePath);
+        updateConfig(this._opts, this._product, previousOpts);
       }
     } else {
       storeConfig(opts, this._product);

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -192,6 +192,7 @@ export abstract class SdkBase {
       let shouldUpdateConfig = false;
       let shouldUpdateCookieOptions = false;
 
+      let previousCookieDomain = this._opts.cookieDomain;
       if (opts.cookieDomain && opts.cookieDomain != this._opts.cookieDomain) {
         shouldUpdateConfig = true;
         shouldUpdateCookieOptions = true;
@@ -202,6 +203,7 @@ export abstract class SdkBase {
         this._logger.log('cookie domain updated');
       }
 
+      let previousCookiePath = this._opts.cookiePath;
       if (opts.cookiePath && opts.cookiePath !== this._opts.cookiePath) {
         shouldUpdateConfig = true;
         shouldUpdateCookieOptions = true;
@@ -248,11 +250,11 @@ export abstract class SdkBase {
         this._logger.log('init callback added to list');
       }
 
-      if (shouldUpdateConfig) {
-        updateConfig(this._opts, this._product);
-      }
       if (shouldUpdateCookieOptions) {
         this._storageManager?.updateCookieOptions(this._opts, this._product.cookieName);
+      }
+      if (shouldUpdateConfig) {
+        updateConfig(this._opts, this._product, previousCookieDomain, previousCookiePath);
       }
     } else {
       storeConfig(opts, this._product);

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -137,10 +137,6 @@ export abstract class SdkBase {
     return this._tokenPromiseHandler.createMaybeDeferredPromise(token ?? null);
   }
 
-  public getInitCallbacks() {
-    return this._initCallbackManager?.getInitCallbacks();
-  }
-
   /**
    * Deprecated
    */

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -215,7 +215,7 @@ export abstract class SdkBase {
         this._logger.log('BaseUrl updated for ApiClient');
       }
 
-      if (opts.identity && opts.identity.identity_expires < Date.now()) {
+      if (opts.identity && opts.identity.identity_expires > Date.now()) {
         if (
           !this._opts.identity ||
           opts.identity.identity_expires > this._opts.identity.identity_expires
@@ -230,7 +230,7 @@ export abstract class SdkBase {
         }
       }
 
-      if (opts.useCookie && this._opts.useCookie !== opts.useCookie) {
+      if (opts.useCookie !== undefined && this._opts.useCookie !== opts.useCookie) {
         shouldUpdateConfig = true;
         this._storageManager?.updateUseCookie(opts.useCookie);
         this._opts.useCookie = opts.useCookie;
@@ -252,7 +252,7 @@ export abstract class SdkBase {
         updateConfig(this._opts, this._product);
       }
       if (shouldUpdateCookieOptions) {
-        this._storageManager?.updateCookieOptions(opts, this._product.cookieName);
+        this._storageManager?.updateCookieOptions(this._opts, this._product.cookieName);
       }
     } else {
       storeConfig(opts, this._product);

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -211,6 +211,7 @@ export abstract class SdkBase {
       }
 
       if (opts.baseUrl && opts.baseUrl !== this._opts.baseUrl) {
+        shouldUpdateConfig = true;
         this._apiClient?.updateBaseUrl(opts.baseUrl);
         this._opts.baseUrl = opts.baseUrl;
         this._logger.log('BaseUrl updated for ApiClient');

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -252,7 +252,7 @@ export abstract class SdkBase {
         this._logger.log('new refresh period set and refresh timer set');
       }
 
-      if (opts.callback) {
+      if (opts.callback && opts.callback !== this._opts.callback) {
         this._initCallbackManager?.addInitCallback(opts.callback);
         if (this._opts.identity) this.validateAndSetIdentity(this._opts.identity);
         this._opts.callback = opts.callback;

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -53,6 +53,7 @@ export abstract class SdkBase {
   private _opts: SdkOptions = {};
   private _identity: Identity | OptoutIdentity | null | undefined;
   private _initComplete = false;
+  private _hasAborted = false;
 
   // Sets up nearly everything, but does not run SdkLoaded callbacks - derived classes must run them.
   protected constructor(existingCallbacks: CallbackHandler[] | undefined, product: ProductDetails) {
@@ -175,7 +176,7 @@ export abstract class SdkBase {
 
   // Note: This doesn't invoke callbacks. It's a hard, silent reset.
   public abort(reason?: string) {
-    this._initComplete = true;
+    this._hasAborted = true;
     this._tokenPromiseHandler.rejectAllPromises(
       reason ?? new Error(`${this._product.name} SDK aborted.`)
     );
@@ -189,6 +190,10 @@ export abstract class SdkBase {
   private initInternal(opts: SdkOptions | unknown) {
     if (!isSDKOptionsOrThrow(opts))
       throw new TypeError(`Options provided to ${this._product.name} init couldn't be validated.`);
+
+    if (this._hasAborted) {
+      throw new TypeError('Calling init() once aborted or disconnected is not allowed');
+    }
 
     if (this.isInitialized()) {
       this.setInitComplete(false);

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -255,6 +255,7 @@ export abstract class SdkBase {
       if (opts.callback) {
         this._initCallbackManager?.addInitCallback(opts.callback);
         if (this._opts.identity) this.validateAndSetIdentity(this._opts.identity);
+        this._opts.callback = opts.callback;
         this._logger.log('init callback added to list');
       }
 

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -136,6 +136,10 @@ export abstract class SdkBase {
     return this._tokenPromiseHandler.createMaybeDeferredPromise(token ?? null);
   }
 
+  public getInitCallbacks() {
+    return this._initCallbackManager?.getInitCallbacks();
+  }
+
   /**
    * Deprecated
    */
@@ -196,9 +200,6 @@ export abstract class SdkBase {
       if (opts.cookieDomain && opts.cookieDomain != this._opts.cookieDomain) {
         shouldUpdateConfig = true;
         shouldUpdateIdentityValue = true;
-        // if (this._opts.useCookie === true || opts.useCookie === true) {
-        //   this._storageManager?.loadIdentity();
-        // }
         this._opts.cookieDomain = opts.cookieDomain;
         this._logger.log('cookie domain updated');
       }
@@ -247,7 +248,8 @@ export abstract class SdkBase {
       }
 
       if (opts.callback) {
-        this._initCallbackManager?.addCallback(opts.callback);
+        this._initCallbackManager?.addInitCallback(opts.callback);
+        if (this._opts.identity) this.validateAndSetIdentity(this._opts.identity);
         this._logger.log('init callback added to list');
       }
 

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -200,28 +200,25 @@ export abstract class SdkBase {
         this._logger.log('BaseUrl updated for ApiClient');
       }
 
-      if (opts.identity) {
-        if (
-          !previousOpts.identity ||
-          opts.identity.identity_expires > previousOpts.identity.identity_expires
-        ) {
-          this.handleNewIdentity(opts.identity);
-          this._logger.log('new identity set');
-        } else {
-          this._opts.identity = previousOpts.identity;
-          this._logger.log('new identity not set because expires before current identity');
+      if (opts.callback && opts.callback !== previousOpts.callback) {
+        this._initCallbackManager?.addInitCallback(opts.callback);
+        this._logger.log('init callback added to list');
+      }
+
+      const useNewIdentity =
+        opts.identity &&
+        (!previousOpts.identity ||
+          opts.identity.identity_expires > previousOpts.identity.identity_expires);
+      if (useNewIdentity || opts.callback) {
+        let identity = useNewIdentity ? opts.identity : previousOpts.identity ?? null;
+        if (identity) {
+          this.handleNewIdentity(identity);
         }
       }
 
       if (opts.refreshRetryPeriod && previousOpts.refreshRetryPeriod !== opts.refreshRetryPeriod) {
         this.setRefreshTimer();
         this._logger.log('new refresh period set and refresh timer set');
-      }
-
-      if (opts.callback && opts.callback !== previousOpts.callback) {
-        this._initCallbackManager?.addInitCallback(opts.callback);
-        if (this._opts.identity) this.validateAndSetIdentity(this._opts.identity);
-        this._logger.log('init callback added to list');
       }
 
       updateConfig(this._opts, this._product, previousOpts);

--- a/src/storageManager.ts
+++ b/src/storageManager.ts
@@ -37,7 +37,7 @@ export class StorageManager {
   public updateValue(opts: SdkOptions, cookieName: string, previousOpts: SdkOptions) {
     if (opts.identity) {
       if (previousOpts.useCookie === true) {
-        this._cookieManager.removeCookie();
+        this._cookieManager.removeCookie(previousOpts);
       } else if (!previousOpts || previousOpts.useCookie === false) {
         this._localStorageManager.removeValue();
       }
@@ -71,12 +71,12 @@ export class StorageManager {
       this._opts.useCookie === false &&
       this._localStorageManager.loadIdentityFromLocalStorage()
     ) {
-      this._cookieManager.removeCookie();
+      this._cookieManager.removeCookie(this._opts);
     }
   }
 
   public removeValues() {
-    this._cookieManager.removeCookie();
+    this._cookieManager.removeCookie(this._opts);
     this._localStorageManager.removeValue();
   }
 }

--- a/src/storageManager.ts
+++ b/src/storageManager.ts
@@ -46,10 +46,6 @@ export class StorageManager {
     }
   }
 
-  public updateUseCookie(useCookie: boolean) {
-    this._opts.useCookie = useCookie;
-  }
-
   public setOptout() {
     const expiry = Date.now() + 72 * 60 * 60 * 1000; // 3 days - need to pick something
     const optout: OptoutIdentity = {

--- a/src/storageManager.ts
+++ b/src/storageManager.ts
@@ -34,17 +34,32 @@ export class StorageManager {
     this.setValue(identity);
   }
 
-  public async updateCookieOptions(opts: SdkOptions, cookieName: string) {
+  public updateValue(opts: SdkOptions, cookieName: string, previousOpts: SdkOptions) {
     if (opts.identity) {
-      this._cookieManager.removeCookie();
+      if (previousOpts.useCookie === true) {
+        this._cookieManager.removeCookie();
+        //this._cookieManager = new CookieManager({ ...opts }, cookieName);
+        // if (opts.useCookie) {
+        //   this._cookieManager.setCookie(opts.identity);
+        // } else {
+        //   this._localStorageManager.setValue(opts.identity);
+        // }
+      } else if (!previousOpts || previousOpts.useCookie === false) {
+        this._localStorageManager.removeValue();
+        //this._cookieManager = new CookieManager({ ...opts }, cookieName);
+        // if (opts.useCookie) {
+        //   this._cookieManager.setCookie(opts.identity);
+        // } else {
+        //   this._localStorageManager.setValue(opts.identity);
+        // }
+      }
       this._cookieManager = new CookieManager({ ...opts }, cookieName);
-      this._cookieManager.setCookie(opts.identity);
+      this.setValue(opts.identity);
     }
   }
 
   public updateUseCookie(useCookie: boolean) {
     this._opts.useCookie = useCookie;
-    this.loadIdentity();
   }
 
   public setOptout() {

--- a/src/storageManager.ts
+++ b/src/storageManager.ts
@@ -34,8 +34,13 @@ export class StorageManager {
     this.setValue(identity);
   }
 
-  public updateCookieManager(opts: SdkOptions, cookieName: string) {
+  public updateCookieOptions(opts: SdkOptions, cookieName: string) {
     this._cookieManager = new CookieManager({ ...opts }, cookieName);
+  }
+
+  public updateUseCookie(useCookie: boolean) {
+    this._opts.useCookie = useCookie;
+    this.loadIdentity();
   }
 
   public setOptout() {

--- a/src/storageManager.ts
+++ b/src/storageManager.ts
@@ -38,20 +38,8 @@ export class StorageManager {
     if (opts.identity) {
       if (previousOpts.useCookie === true) {
         this._cookieManager.removeCookie();
-        //this._cookieManager = new CookieManager({ ...opts }, cookieName);
-        // if (opts.useCookie) {
-        //   this._cookieManager.setCookie(opts.identity);
-        // } else {
-        //   this._localStorageManager.setValue(opts.identity);
-        // }
       } else if (!previousOpts || previousOpts.useCookie === false) {
         this._localStorageManager.removeValue();
-        //this._cookieManager = new CookieManager({ ...opts }, cookieName);
-        // if (opts.useCookie) {
-        //   this._cookieManager.setCookie(opts.identity);
-        // } else {
-        //   this._localStorageManager.setValue(opts.identity);
-        // }
       }
       this._cookieManager = new CookieManager({ ...opts }, cookieName);
       this.setValue(opts.identity);

--- a/src/storageManager.ts
+++ b/src/storageManager.ts
@@ -35,9 +35,9 @@ export class StorageManager {
   }
 
   public async updateCookieOptions(opts: SdkOptions, cookieName: string) {
-    this._cookieManager = new CookieManager({ ...opts }, cookieName);
     if (opts.identity) {
-      await this._cookieManager.removeCookie();
+      this._cookieManager.removeCookie();
+      this._cookieManager = new CookieManager({ ...opts }, cookieName);
       this._cookieManager.setCookie(opts.identity);
     }
   }

--- a/src/storageManager.ts
+++ b/src/storageManager.ts
@@ -34,8 +34,12 @@ export class StorageManager {
     this.setValue(identity);
   }
 
-  public updateCookieOptions(opts: SdkOptions, cookieName: string) {
+  public async updateCookieOptions(opts: SdkOptions, cookieName: string) {
     this._cookieManager = new CookieManager({ ...opts }, cookieName);
+    if (opts.identity) {
+      await this._cookieManager.removeCookie();
+      this._cookieManager.setCookie(opts.identity);
+    }
   }
 
   public updateUseCookie(useCookie: boolean) {

--- a/src/storageManager.ts
+++ b/src/storageManager.ts
@@ -34,6 +34,10 @@ export class StorageManager {
     this.setValue(identity);
   }
 
+  public updateCookieManager(opts: SdkOptions, cookieName: string) {
+    this._cookieManager = new CookieManager({ ...opts }, cookieName);
+  }
+
   public setOptout() {
     const expiry = Date.now() + 72 * 60 * 60 * 1000; // 3 days - need to pick something
     const optout: OptoutIdentity = {


### PR DESCRIPTION
What Changed:

- No more error on multiple init calls
- Different process whether init has already been called or if it is the first init call
- Params updated (baseUrl, identity if it expires after the current identity, cookiePath, cookieDomain, refreshRetryPeriod, useCookie
- Config updated if any params have changed or if the method of storing identity (cookie or local storage has changed)
- Way to store identity (cookie or local storage) updated if useCookie changes 
- initCallback is now a class, when init callback gets sent, it is added to an array of previous init callbacks
- Added new variable if aborted, abort no longer = init complete since we can have multiple init calls
- function `isInitialized` added so client knows if it has already been initialized, they might not want to do it again
- Tests added 
- per the ticket, logs added to help with debugging

Test Plan:
- Run the local cstg example from the web-integrations repo -> Run and debug -> Launch cstg (chrome).  Make sure local operator is running (go to `uid2-dev-workspace` -> run `docker compose up` -> and check `http://localhost:8080/ops/healthcheck` to make sure it is running 
- Change the `index.html` file in the cstg example to call init multiple times and change the parameters from SdkOptions each time.  Make sure everything still functions as normal in the example site (`baseUrl` has to be on localhost, but you can test that changing it to something else makes the example not work) 
 
