### PR TITLE
 js sdk bootstrap init call

### DIFF
--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -25,12 +25,10 @@ export const storeConfig = (options: SdkOptions, productDetails: ProductDetails)
   }
 };
 
-export const loadConfig = (
-  options: SdkOptions,
-  productDetails: ProductDetails
-): storedConfig | null => {
-  if (options.useCookie) {
-    return loadConfigFromCookie(productDetails);
+export const loadConfig = (productDetails: ProductDetails): storedConfig | null => {
+  const configCookie = loadConfigFromCookie(productDetails);
+  if (configCookie) {
+    return configCookie;
   } else {
     return loadConfigFromLocalStorage(productDetails);
   }

--- a/src/euidSdk.ts
+++ b/src/euidSdk.ts
@@ -62,6 +62,15 @@ export function assertEUID(sdk: typeof window.__euid): asserts sdk is EUID {
   if (!(sdk instanceof EUID)) throw new Error(sdkAssertErrorText('EUID', 'assertEUID'));
 }
 
+function bootStrapInit() {
+  if (window.__euid instanceof EUID) {
+    const config = loadConfig(productDetails);
+    if (config) {
+      window.__euid.init(config);
+    }
+  }
+}
+
 export function __euidInternalHandleScriptLoad() {
   if (window.__euid && 'init' in window.__euid) {
     // This has already been run
@@ -72,12 +81,7 @@ export function __euidInternalHandleScriptLoad() {
   const callbackContainer: CallbackContainer = {};
   window.__euid = new EUID(callbacks, callbackContainer);
   if (callbackContainer.callback) callbackContainer.callback();
-  if (window.__euid instanceof EUID) {
-    const config = loadConfig(productDetails);
-    if (config) {
-      window.__euid.init(config);
-    }
-  }
+  bootStrapInit();
 }
 __euidInternalHandleScriptLoad();
 

--- a/src/euidSdk.ts
+++ b/src/euidSdk.ts
@@ -62,7 +62,7 @@ export function assertEUID(sdk: typeof window.__euid): asserts sdk is EUID {
   if (!(sdk instanceof EUID)) throw new Error(sdkAssertErrorText('EUID', 'assertEUID'));
 }
 
-function bootStrapInit() {
+function bootstrapInit() {
   if (window.__euid instanceof EUID) {
     const config = loadConfig(productDetails);
     if (config) {
@@ -81,7 +81,7 @@ export function __euidInternalHandleScriptLoad() {
   const callbackContainer: CallbackContainer = {};
   window.__euid = new EUID(callbacks, callbackContainer);
   if (callbackContainer.callback) callbackContainer.callback();
-  bootStrapInit();
+  bootstrapInit();
 }
 __euidInternalHandleScriptLoad();
 

--- a/src/euidSdk.ts
+++ b/src/euidSdk.ts
@@ -2,6 +2,7 @@ import { EventType, CallbackHandler } from './callbackManager';
 import { CallbackContainer, sdkAssertErrorText, SdkBase, SDKSetup } from './sdkBase';
 import { ProductDetails } from './product';
 import { UidSecureSignalProviderType } from './secureSignal_types';
+import { loadConfig } from './configManager';
 
 export * from './exports';
 
@@ -14,7 +15,7 @@ export class EUID extends SdkBase {
     );
     return EUID.cookieName;
   }
-  private static get EuidDetails(): ProductDetails {
+  static get EuidDetails(): ProductDetails {
     return {
       name: 'EUID',
       defaultBaseUrl: 'https://prod.euid.eu',
@@ -69,6 +70,12 @@ export function __euidInternalHandleScriptLoad() {
   const callbackContainer: CallbackContainer = {};
   window.__euid = new EUID(callbacks, callbackContainer);
   if (callbackContainer.callback) callbackContainer.callback();
+  if (window.__uid2 instanceof EUID) {
+    const config = loadConfig(EUID.EuidDetails);
+    if (config) {
+      window.__uid2.init(config);
+    }
+  }
 }
 __euidInternalHandleScriptLoad();
 

--- a/src/euidSdk.ts
+++ b/src/euidSdk.ts
@@ -6,8 +6,15 @@ import { loadConfig } from './configManager';
 
 export * from './exports';
 
+const productDetails: ProductDetails = {
+  name: 'EUID',
+  defaultBaseUrl: 'https://prod.euid.eu',
+  localStorageKey: 'EUID-sdk-identity',
+  cookieName: '__euid',
+};
+
 export class EUID extends SdkBase {
-  private static cookieName = '__euid';
+  private static cookieName = productDetails.cookieName;
   // Deprecated. Integrators should never access the cookie directly!
   static get COOKIE_NAME() {
     console.warn(
@@ -16,12 +23,7 @@ export class EUID extends SdkBase {
     return EUID.cookieName;
   }
   static get EuidDetails(): ProductDetails {
-    return {
-      name: 'EUID',
-      defaultBaseUrl: 'https://prod.euid.eu',
-      localStorageKey: 'EUID-sdk-identity',
-      cookieName: EUID.cookieName,
-    };
+    return productDetails;
   }
 
   static setupGoogleTag() {
@@ -71,7 +73,7 @@ export function __euidInternalHandleScriptLoad() {
   window.__euid = new EUID(callbacks, callbackContainer);
   if (callbackContainer.callback) callbackContainer.callback();
   if (window.__euid instanceof EUID) {
-    const config = loadConfig(EUID.EuidDetails);
+    const config = loadConfig(productDetails);
     if (config) {
       window.__euid.init(config);
     }

--- a/src/euidSdk.ts
+++ b/src/euidSdk.ts
@@ -70,10 +70,10 @@ export function __euidInternalHandleScriptLoad() {
   const callbackContainer: CallbackContainer = {};
   window.__euid = new EUID(callbacks, callbackContainer);
   if (callbackContainer.callback) callbackContainer.callback();
-  if (window.__uid2 instanceof EUID) {
+  if (window.__euid instanceof EUID) {
     const config = loadConfig(EUID.EuidDetails);
     if (config) {
-      window.__uid2.init(config);
+      window.__euid.init(config);
     }
   }
 }

--- a/src/integrationTests/basic.test.ts
+++ b/src/integrationTests/basic.test.ts
@@ -1071,7 +1071,7 @@ describe('SDK bootstraps itself if init has already been completed', () => {
     sdkWindow.__uid2 = new UID2();
   });
 
-  test('sdk bootstraps with config after init has already been called', async () => {
+  test('should bootstrap therefore public functions should return the correct values without calling init again', async () => {
     const identity = { ...makeIdentity(), refresh_from: Date.now() + 100 };
 
     uid2.init({ identity });
@@ -1091,7 +1091,7 @@ describe('SDK bootstraps itself if init has already been completed', () => {
     }).not.toThrow();
   });
 
-  test('sdk does not bootstrap if no init has occurred', async () => {
+  test('should not bootstrap therefore public functions error or return undefined/null', async () => {
     __uid2InternalHandleScriptLoad();
     expect(uid2.getAdvertisingToken()).toBe(undefined);
     expect(uid2.getIdentity()).toStrictEqual(null);

--- a/src/integrationTests/basic.test.ts
+++ b/src/integrationTests/basic.test.ts
@@ -3,9 +3,6 @@ import { afterEach, beforeEach, describe, expect, jest, test } from '@jest/globa
 import * as mocks from '../mocks';
 import { __uid2InternalHandleScriptLoad, sdkWindow, UID2 } from '../uid2Sdk';
 import { CallbackHandler, EventType } from '../callbackManager';
-import { ProductDetails } from '../product';
-import { loadConfig } from '../configManager';
-import { error } from 'console';
 
 let callback: any;
 let uid2: UID2;

--- a/src/integrationTests/basic.test.ts
+++ b/src/integrationTests/basic.test.ts
@@ -1067,15 +1067,8 @@ describe('Include sdk script multiple times', () => {
 
 describe('SDK bootstraps itself if init has already been completed', () => {
   const makeIdentity = mocks.makeIdentityV2;
-  let asyncCallback: jest.Mock<CallbackHandler>;
-  const debugOutput = false;
-
-  asyncCallback = jest.fn((event, payload) => {
-    if (debugOutput) {
-      console.log('Async Callback Event:', event);
-      console.log('Payload:', payload);
-    }
-  });
+  const email = 'test@test.com';
+  const emailHash = 'lz3+Rj7IV4X1+Vr1ujkG7tstkxwk5pgkqJ6mXbpOgTs=';
 
   beforeEach(() => {
     sdkWindow.__uid2 = new UID2();
@@ -1086,25 +1079,30 @@ describe('SDK bootstraps itself if init has already been completed', () => {
 
     uid2.init({ identity });
 
-    // mimicking closing the page
+    // mimicking closing the page, but not re-calling the UID2 constructor
     sdkWindow.__uid2 = undefined;
 
     __uid2InternalHandleScriptLoad();
 
     expect(uid2.getAdvertisingToken()).toBe(identity.advertising_token);
     expect(uid2.getIdentity()).toStrictEqual(identity);
-    // expect(() => uid2.setIdentityFromEmail('test@test.com', mocks.makeCstgOption())).not.toThrow(
-    //   error
-    // );
-    // expect(() =>
-    //   uid2.setIdentityFromEmailHash(
-    //     'lz3+Rj7IV4X1+Vr1ujkG7tstkxwk5pgkqJ6mXbpOgTs=',
-    //     mocks.makeCstgOption()
-    //   )
-    // ).not.toThrow(error);
+    expect(async () => {
+      await uid2.setIdentityFromEmail(email, mocks.makeCstgOption());
+    }).not.toThrow();
+    expect(async () => {
+      uid2.setIdentityFromEmailHash(emailHash, mocks.makeCstgOption());
+    }).not.toThrow();
   });
 
   test('sdk does not bootstrap if no init has occurred', async () => {
     __uid2InternalHandleScriptLoad();
+    expect(uid2.getAdvertisingToken()).toBe(undefined);
+    expect(uid2.getIdentity()).toStrictEqual(null);
+    expect(async () => {
+      await uid2.setIdentityFromEmail(email, mocks.makeCstgOption());
+    }).rejects.toThrow();
+    expect(async () => {
+      await uid2.setIdentityFromEmailHash(emailHash, mocks.makeCstgOption());
+    }).rejects.toThrow();
   });
 });

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -548,13 +548,8 @@ describe('Store config UID2', () => {
       let storageConfig = loadConfig(productDetails);
       expect(storageConfig).toBeInstanceOf(Object);
       expect(storageConfig).toHaveProperty('cookieDomain');
-<<<<<<< HEAD
-      removeConfig(options, productDetails);
-      storageConfig = loadConfig(productDetails);
-=======
       removeConfig(previousOptions, productDetails);
-      storageConfig = loadConfig(options, productDetails);
->>>>>>> main
+      storageConfig = loadConfig(productDetails);
       expect(storageConfig).toBeNull();
     });
   });

--- a/src/integrationTests/options.test.ts
+++ b/src/integrationTests/options.test.ts
@@ -236,14 +236,14 @@ describe('Store config UID2', () => {
       const cookie = getConfigCookie();
       expect(cookie).toBeInstanceOf(Object);
       expect(cookie).toHaveProperty('cookieDomain');
-      const storageConfig = loadConfig(options, productDetails);
+      const storageConfig = loadConfig(productDetails);
       expect(storageConfig).toBeNull();
     });
   });
   describe('when useCookie is false', () => {
     test('should store config in local storage', () => {
       uid2.init({ callback: callback, identity: identity, ...options });
-      const storageConfig = loadConfig(options, productDetails);
+      const storageConfig = loadConfig(productDetails);
       expect(storageConfig).toBeInstanceOf(Object);
       expect(storageConfig).toHaveProperty('cookieDomain');
       const cookie = getConfigCookie();
@@ -253,11 +253,11 @@ describe('Store config UID2', () => {
   describe('when useCookie is false', () => {
     test('can successfully clear the config in storage', () => {
       uid2.init({ callback: callback, identity: identity, ...options });
-      let storageConfig = loadConfig(options, productDetails);
+      let storageConfig = loadConfig(productDetails);
       expect(storageConfig).toBeInstanceOf(Object);
       expect(storageConfig).toHaveProperty('cookieDomain');
       removeConfig(options, productDetails);
-      storageConfig = loadConfig(options, productDetails);
+      storageConfig = loadConfig(productDetails);
       expect(storageConfig).toBeNull();
     });
   });

--- a/src/integrationTests/secureSignal.test.ts
+++ b/src/integrationTests/secureSignal.test.ts
@@ -184,8 +184,10 @@ describe('Secure Signal Tests', () => {
     });
 
     describe('When SDK initialized after both SDK and SS script loaded - UID2', () => {
-      test('should send identity to Google ESP', async () => {
+      beforeEach(() => {
         window.__uid2 = new UID2();
+      });
+      test('should send identity to Google ESP', async () => {
         __uid2InternalHandleScriptLoad();
         __uid2SSProviderScriptLoad();
         (window.__uid2 as UID2).init({ identity });

--- a/src/integrationTests/secureSignal.test.ts
+++ b/src/integrationTests/secureSignal.test.ts
@@ -185,6 +185,7 @@ describe('Secure Signal Tests', () => {
 
     describe('When SDK initialized after both SDK and SS script loaded - UID2', () => {
       test('should send identity to Google ESP', async () => {
+        window.__uid2 = new UID2();
         __uid2InternalHandleScriptLoad();
         __uid2SSProviderScriptLoad();
         (window.__uid2 as UID2).init({ identity });

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -139,6 +139,10 @@ export abstract class SdkBase {
     return !(this.isLoggedIn() || this._apiClient?.hasActiveRequests());
   }
 
+  public isInitialized() {
+    return this._initComplete;
+  }
+
   public hasOptedOut() {
     if (!this._initComplete) return undefined;
     return isOptoutIdentity(this._identity);

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -74,10 +74,6 @@ export abstract class SdkBase {
     this.initInternal(opts);
   }
 
-  public isInitialized() {
-    return this._initComplete;
-  }
-
   private setInitComplete(isInitComplete: boolean) {
     this._initComplete = isInitComplete;
   }

--- a/src/sdkBase.ts
+++ b/src/sdkBase.ts
@@ -133,7 +133,7 @@ export abstract class SdkBase {
     return this._tokenPromiseHandler.createMaybeDeferredPromise(token ?? null);
   }
 
-  public initComplete(): boolean {
+  public isInitComplete(): boolean {
     return this._initComplete;
   }
 
@@ -147,10 +147,6 @@ export abstract class SdkBase {
   public hasIdentity() {
     if (!this._initComplete) return undefined;
     return !(this.isLoggedIn() || this._apiClient?.hasActiveRequests());
-  }
-
-  public isInitialized() {
-    return this._initComplete;
   }
 
   public hasOptedOut() {
@@ -195,7 +191,7 @@ export abstract class SdkBase {
       throw new TypeError('Calling init() once aborted or disconnected is not allowed');
     }
 
-    if (this.isInitialized()) {
+    if (this.isInitComplete()) {
       const previousOpts = { ...this._opts };
       Object.assign(this._opts, opts);
 

--- a/src/uid2Sdk.ts
+++ b/src/uid2Sdk.ts
@@ -8,6 +8,7 @@ import { isBase64Hash } from './hashedDii';
 import { hashAndEncodeIdentifier, hashIdentifier } from './encoding/hash';
 import { CallbackContainer, sdkAssertErrorText, SdkBase, SDKSetup } from './sdkBase';
 import { ProductDetails } from './product';
+import { loadConfig } from './configManager';
 
 export * from './exports';
 
@@ -38,7 +39,7 @@ export class UID2 extends SdkBase {
     );
     return UID2.cookieName;
   }
-  private static get Uid2Details(): ProductDetails {
+  static get Uid2Details(): ProductDetails {
     return {
       name: 'UID2',
       defaultBaseUrl: 'https://prod.uidapi.com',
@@ -113,6 +114,12 @@ export function __uid2InternalHandleScriptLoad() {
   window.__uid2 = new UID2(callbacks, callbackContainer);
   window.__uid2Helper = new UID2Helper();
   if (callbackContainer.callback) callbackContainer.callback();
+  if (window.__uid2 instanceof UID2 && window.__uid2.isInitialized()) {
+    const config = loadConfig(UID2.Uid2Details);
+    if (config) {
+      window.__uid2.init(config);
+    }
+  }
 }
 __uid2InternalHandleScriptLoad();
 

--- a/src/uid2Sdk.ts
+++ b/src/uid2Sdk.ts
@@ -112,6 +112,15 @@ export function assertUID2(sdk: typeof window.__uid2): asserts sdk is UID2 {
   if (!(sdk instanceof UID2)) throw new Error(sdkAssertErrorText('UID2', 'assertUID2'));
 }
 
+function bootStrapInit() {
+  if (window.__uid2 instanceof UID2) {
+    const config = loadConfig(productDetails);
+    if (config) {
+      window.__uid2.init(config);
+    }
+  }
+}
+
 export function __uid2InternalHandleScriptLoad() {
   if (window.__uid2 && 'init' in window.__uid2) {
     // This has already been run
@@ -123,12 +132,7 @@ export function __uid2InternalHandleScriptLoad() {
   window.__uid2 = new UID2(callbacks, callbackContainer);
   window.__uid2Helper = new UID2Helper();
   if (callbackContainer.callback) callbackContainer.callback();
-  if (window.__uid2 instanceof UID2) {
-    const config = loadConfig(productDetails);
-    if (config) {
-      window.__uid2.init(config);
-    }
-  }
+  bootStrapInit();
 }
 __uid2InternalHandleScriptLoad();
 

--- a/src/uid2Sdk.ts
+++ b/src/uid2Sdk.ts
@@ -31,8 +31,15 @@ export class UID2Helper {
   }
 }
 
+const productDetails: ProductDetails = {
+  name: 'UID2',
+  defaultBaseUrl: 'https://prod.uidapi.com',
+  localStorageKey: 'UID2-sdk-identity',
+  cookieName: '__uid_2',
+};
+
 export class UID2 extends SdkBase {
-  private static cookieName = '__uid_2';
+  private static cookieName = productDetails.cookieName;
   // Deprecated. Integrators should never access the cookie directly!
   static get COOKIE_NAME() {
     console.warn(
@@ -40,13 +47,8 @@ export class UID2 extends SdkBase {
     );
     return UID2.cookieName;
   }
-  static get Uid2Details(): ProductDetails {
-    return {
-      name: 'UID2',
-      defaultBaseUrl: 'https://prod.uidapi.com',
-      localStorageKey: 'UID2-sdk-identity',
-      cookieName: UID2.cookieName,
-    };
+  private static get Uid2Details(): ProductDetails {
+    return productDetails;
   }
 
   static setupGoogleTag() {
@@ -122,7 +124,7 @@ export function __uid2InternalHandleScriptLoad() {
   window.__uid2Helper = new UID2Helper();
   if (callbackContainer.callback) callbackContainer.callback();
   if (window.__uid2 instanceof UID2) {
-    const config = loadConfig(UID2.Uid2Details);
+    const config = loadConfig(productDetails);
     if (config) {
       window.__uid2.init(config);
     }

--- a/src/uid2Sdk.ts
+++ b/src/uid2Sdk.ts
@@ -125,7 +125,6 @@ export function __uid2InternalHandleScriptLoad() {
     const config = loadConfig(UID2.Uid2Details);
     if (config) {
       window.__uid2.init(config);
-      console.log('bootstrapping');
     }
   }
 }

--- a/src/uid2Sdk.ts
+++ b/src/uid2Sdk.ts
@@ -121,10 +121,11 @@ export function __uid2InternalHandleScriptLoad() {
   window.__uid2 = new UID2(callbacks, callbackContainer);
   window.__uid2Helper = new UID2Helper();
   if (callbackContainer.callback) callbackContainer.callback();
-  if (window.__uid2 instanceof UID2 && window.__uid2.isInitComplete()) {
+  if (window.__uid2 instanceof UID2) {
     const config = loadConfig(UID2.Uid2Details);
     if (config) {
       window.__uid2.init(config);
+      console.log('bootstrapping');
     }
   }
 }

--- a/src/uid2Sdk.ts
+++ b/src/uid2Sdk.ts
@@ -121,7 +121,7 @@ export function __uid2InternalHandleScriptLoad() {
   window.__uid2 = new UID2(callbacks, callbackContainer);
   window.__uid2Helper = new UID2Helper();
   if (callbackContainer.callback) callbackContainer.callback();
-  if (window.__uid2 instanceof UID2 && window.__uid2.isInitialized()) {
+  if (window.__uid2 instanceof UID2 && window.__uid2.isInitComplete()) {
     const config = loadConfig(UID2.Uid2Details);
     if (config) {
       window.__uid2.init(config);

--- a/src/uid2Sdk.ts
+++ b/src/uid2Sdk.ts
@@ -112,7 +112,7 @@ export function assertUID2(sdk: typeof window.__uid2): asserts sdk is UID2 {
   if (!(sdk instanceof UID2)) throw new Error(sdkAssertErrorText('UID2', 'assertUID2'));
 }
 
-function bootStrapInit() {
+function bootstrapInit() {
   if (window.__uid2 instanceof UID2) {
     const config = loadConfig(productDetails);
     if (config) {
@@ -132,7 +132,7 @@ export function __uid2InternalHandleScriptLoad() {
   window.__uid2 = new UID2(callbacks, callbackContainer);
   window.__uid2Helper = new UID2Helper();
   if (callbackContainer.callback) callbackContainer.callback();
-  bootStrapInit();
+  bootstrapInit();
 }
 __uid2InternalHandleScriptLoad();
 


### PR DESCRIPTION
What Changed:

- Added ability to call init from the load script if a config exists (for UID2 and EUID)
- Added tests to make sure the public functions return the correct value without init being called if bootstrap has occurred
- Added tests to make sure the public functions error if bootstrap did not occur