### PR TITLE
Sas UI d2 1845 remove preflight check add version

### DIFF
--- a/localtest/shared/uid2SdkTag.html
+++ b/localtest/shared/uid2SdkTag.html
@@ -1,1 +1,2 @@
-<script src="https://cdn.integ.uidapi.com/uid2-sdk-3.5.0.js"></script>
+<!-- <script src="https://cdn.integ.uidapi.com/uid2-sdk-3.5.0.js"></script> -->
+<script src="../../dist/uid2-sdk-3.10.0.js"></script>

--- a/localtest/shared/uid2SdkTag.html
+++ b/localtest/shared/uid2SdkTag.html
@@ -1,2 +1,2 @@
-<!-- <script src="https://cdn.integ.uidapi.com/uid2-sdk-3.5.0.js"></script> -->
-<script src="../../dist/uid2-sdk-3.10.0.js"></script>
+<script src="https://cdn.integ.uidapi.com/uid2-sdk-3.5.0.js"></script>
+<!-- <script src="../../dist/uid2-sdk-3.10.0.js"></script> -->

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -149,7 +149,7 @@ export class ApiClient {
   }
 
   public callRefreshApi(refreshDetails: Identity): Promise<RefreshResult> {
-    const url = this._baseUrl + `/v2/token/refresh?version=${this._clientVersion}`;
+    const url = this._baseUrl + `/v2/token/refresh?client=${this._clientVersion}`;
     const req = new XMLHttpRequest();
     this._requestsInFlight.push(req);
     req.overrideMimeType('text/plain');
@@ -242,7 +242,7 @@ export class ApiClient {
       subscription_id: opts.subscriptionId,
     };
 
-    const url = this._baseUrl + `/v2/token/client-generate?version=${this._clientVersion}`;
+    const url = this._baseUrl + `/v2/token/client-generate?client=${this._clientVersion}`;
     const req = new XMLHttpRequest();
     this._requestsInFlight.push(req);
     req.overrideMimeType('text/plain');

--- a/src/apiClient.ts
+++ b/src/apiClient.ts
@@ -149,12 +149,11 @@ export class ApiClient {
   }
 
   public callRefreshApi(refreshDetails: Identity): Promise<RefreshResult> {
-    const url = this._baseUrl + '/v2/token/refresh';
+    const url = this._baseUrl + `/v2/token/refresh?version=${this._clientVersion}`;
     const req = new XMLHttpRequest();
     this._requestsInFlight.push(req);
     req.overrideMimeType('text/plain');
     req.open('POST', url, true);
-    req.setRequestHeader('X-UID2-Client-Version', this._clientVersion); // N.B. EUID and UID2 currently both use the same header
     let resolvePromise: (result: RefreshResult) => void;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     let rejectPromise: (reason?: any) => void;
@@ -221,7 +220,7 @@ export class ApiClient {
     opts: ClientSideIdentityOptions
   ): Promise<CstgResult> {
     const request =
-        'emailHash' in data ? { email_hash: data.emailHash } : { phone_hash: data.phoneHash };
+      'emailHash' in data ? { email_hash: data.emailHash } : { phone_hash: data.phoneHash };
 
     const box = await CstgBox.build(stripPublicKeyPrefix(opts.serverPublicKey));
 
@@ -243,7 +242,7 @@ export class ApiClient {
       subscription_id: opts.subscriptionId,
     };
 
-    const url = this._baseUrl + '/v2/token/client-generate';
+    const url = this._baseUrl + `/v2/token/client-generate?version=${this._clientVersion}`;
     const req = new XMLHttpRequest();
     this._requestsInFlight.push(req);
     req.overrideMimeType('text/plain');

--- a/src/integrationTests/basic.test.ts
+++ b/src/integrationTests/basic.test.ts
@@ -33,7 +33,7 @@ const makeIdentityV2 = mocks.makeIdentityV2;
 let useCookie: boolean | undefined = undefined;
 
 const UID2Version = 'uid2' + '-sdk-' + UID2.VERSION;
-const uid2RefreshUrl = `https://prod.uidapi.com/v2/token/refresh?version=${UID2Version}`;
+const uid2RefreshUrl = `https://prod.uidapi.com/v2/token/refresh?client=${UID2Version}`;
 
 const testCookieAndLocalStorage = (test: () => void, only = false) => {
   const describeFn = only ? describe.only : describe;

--- a/src/integrationTests/basic.test.ts
+++ b/src/integrationTests/basic.test.ts
@@ -32,6 +32,9 @@ const makeIdentityV2 = mocks.makeIdentityV2;
 
 let useCookie: boolean | undefined = undefined;
 
+const UID2Version = 'uid2' + '-sdk-' + UID2.VERSION;
+const uid2RefreshUrl = `https://prod.uidapi.com/v2/token/refresh?version=${UID2Version}`;
+
 const testCookieAndLocalStorage = (test: () => void, only = false) => {
   const describeFn = only ? describe.only : describe;
   describeFn('Using default: ', () => {
@@ -292,8 +295,7 @@ testCookieAndLocalStorage(() => {
 
       test('should initiate token refresh', () => {
         expect(xhrMock.send).toHaveBeenCalledTimes(1);
-        const url = 'https://prod.uidapi.com/v2/token/refresh';
-        expect(xhrMock.open).toHaveBeenLastCalledWith('POST', url, true);
+        expect(xhrMock.open).toHaveBeenLastCalledWith('POST', uid2RefreshUrl, true);
         expect(xhrMock.send).toHaveBeenLastCalledWith(identity.refresh_token);
         xhrMock.onreadystatechange();
         expect(cryptoMock.subtle.importKey).toHaveBeenCalled();
@@ -321,8 +323,7 @@ testCookieAndLocalStorage(() => {
       test('should initiate token refresh', () => {
         const cryptoMock = new mocks.CryptoMock(sdkWindow);
         expect(xhrMock.send).toHaveBeenCalledTimes(1);
-        const url = 'https://prod.uidapi.com/v2/token/refresh';
-        expect(xhrMock.open).toHaveBeenLastCalledWith('POST', url, true);
+        expect(xhrMock.open).toHaveBeenLastCalledWith('POST', uid2RefreshUrl, true);
         expect(xhrMock.send).toHaveBeenLastCalledWith(identity.refresh_token);
         xhrMock.onreadystatechange();
         expect(cryptoMock.subtle.importKey).toHaveBeenCalledTimes(0);


### PR DESCRIPTION
- Remove request header that caused a preflight round trip.
- Send client version in query param