### PR TITLE
UID2-6838: upgrade path-to-regexp to fix CVE-2026-4926 (GHSA-j3q9-mxjg-w52f)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "axios": "^1.13.5",
         "body-parser": "^1.20.3",
-        "path-to-regexp": "^8.2.0"
+        "path-to-regexp": "^8.4.0"
       },
       "devDependencies": {
         "@jest/globals": "^29.2.2",
@@ -9117,11 +9117,13 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
-      "engines": {
-        "node": ">=16"
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.1.tgz",
+      "integrity": "sha512-fvU78fIjZ+SBM9YwCknCvKOUKkLVqtWDVctl0s7xIqfmfb38t2TT4ZU2gHm+Z8xGwgW+QWEU3oQSAzIbo89Ggw==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/path-type": {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "axios": "^1.13.5",
     "body-parser": "^1.20.3",
-    "path-to-regexp": "^8.2.0"
+    "path-to-regexp": "^8.4.0"
   },
   "overrides": {
     "form-data": "^4.0.4",


### PR DESCRIPTION
## Summary

Upgrades `path-to-regexp` from `8.2.0` → `8.4.1` to fix a HIGH severity DoS vulnerability.

- **CVE:** CVE-2026-4926
- **GHSA:** GHSA-j3q9-mxjg-w52f
- **Severity:** HIGH (CVSS 7.5)
- **Jira:** [UID2-6838](https://thetradedesk.atlassian.net/browse/UID2-6838)

## Vulnerability Details

`path-to-regexp` versions 8.0.0–8.3.x generate exponentially large regexes when route patterns contain multiple sequential optional groups (e.g. `{a}{b}{c}:z`). This causes uncontrolled resource consumption (CWE-400, CWE-1333), enabling a network-accessible DoS with no authentication required.

This repo had `path-to-regexp@8.2.0` locked in `package-lock.json`.

## Fix

Bumped the range from `^8.2.0` to `^8.4.0` in `package.json`; `npm install` resolved to `8.4.1`.

## Testing

All 811 unit and integration tests pass locally.

## Repo Scope

Only `IABTechLab/uid2-web-integrations` is affected. No other repos across IABTechLab, UnifiedID2, or European-Unified-ID use `path-to-regexp` in the 8.x range.