### PR TITLE
[UID2-6900] Fix CVE-2025-62718: Upgrade axios 1.13.5→1.15.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "4.0.88",
       "license": "Apache 2.0",
       "dependencies": {
-        "axios": "^1.13.5",
+        "axios": "^1.15.0",
         "body-parser": "^1.20.3",
         "path-to-regexp": "^8.4.0"
       },
@@ -3028,13 +3028,13 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/babel-jest": {
@@ -9942,9 +9942,12 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/psl": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "webpack-dev-server": "^5.1.0"
   },
   "dependencies": {
-    "axios": "^1.13.5",
+    "axios": "^1.15.0",
     "body-parser": "^1.20.3",
     "path-to-regexp": "^8.4.0"
   },


### PR DESCRIPTION
## Summary

- **CVE:** CVE-2025-62718 — axios NO_PROXY Hostname Normalization Bypass → SSRF (CRITICAL)
- Upgrades `axios` from `^1.13.5` to `^1.15.0` in `package.json` to remediate the vulnerability
- All 19 test suites (811 tests) pass with the upgraded version

## Vulnerability Details

**CVE-2025-62718** is a CRITICAL Server-Side Request Forgery (SSRF) vulnerability in axios where the `NO_PROXY` environment variable hostname normalization can be bypassed. An attacker can exploit this to make the server issue requests to internal/restricted hosts that should be blocked by `NO_PROXY` rules.

**Affected version:** axios < 1.15.0
**Fixed version:** axios >= 1.15.0

## Changes

- `package.json`: Updated `axios` dependency from `^1.13.5` to `^1.15.0`
- `package-lock.json`: Regenerated to reflect axios 1.15.0

## Jira Ticket

[UID2-6900](https://thetradedesk.atlassian.net/browse/UID2-6900)

## Test Plan

- [x] `npm install` completed successfully with axios 1.15.0
- [x] All 19 test suites passed (`npm test`): 811 tests passed, 14 skipped
- [x] Verified `package-lock.json` resolves `node_modules/axios` to version 1.15.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)