### PR TITLE
UID2-6913: Pin third-party GitHub Action refs to commit SHAs

### DIFF
--- a/.github/actions/cdn_deployment_aws/action.yaml
+++ b/.github/actions/cdn_deployment_aws/action.yaml
@@ -24,7 +24,7 @@ runs:
 
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@v4
+      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
       with:
         aws-region: us-east-2
         role-to-assume: arn:aws:iam::${{ inputs.aws_account_id }}:role/github-runner-for-cdn
@@ -77,7 +77,7 @@ runs:
         aws s3 cp index.html s3://${{ inputs.aws_bucket_name }}/index.html
 
     - name: Invalidate CloudFront
-      uses: chetan/invalidate-cloudfront-action@v2
+      uses: chetan/invalidate-cloudfront-action@cacab256f2bd90d1c04447a7d6afdaf6f346e7b3 # v2
       env:
         DISTRIBUTION: ${{ inputs.aws_distribution_id }}
         PATHS: ${{ inputs.invalidate_paths }}

--- a/.github/workflows/build-sdk-package.yml
+++ b/.github/workflows/build-sdk-package.yml
@@ -91,7 +91,7 @@ jobs:
     steps:
       - name: Build Changelog
         id: github_release_changelog
-        uses: mikepenz/release-changelog-builder-action@v4
+        uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
         with:
           toTag: v${{ needs.incrementVersionNumber.outputs.new_version }}
           configurationJson: |
@@ -99,7 +99,7 @@ jobs:
               "pr_template": " - #{{TITLE}} - ( PR: ##{{NUMBER}} )"
             }
       - name: Create Release Notes
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           name: v${{ needs.incrementVersionNumber.outputs.new_version }}
           body: ${{ steps.github_release_changelog.outputs.changelog }}

--- a/.github/workflows/build-secure-signal.yml
+++ b/.github/workflows/build-secure-signal.yml
@@ -17,12 +17,12 @@ jobs:
       - uses: actions/checkout@v4
       - name: Check for change to src/secureSignalUid2.ts
         id: verify_uid2
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@716b1e13042866565e00e85fd4ec490e186c4a2f # v41
         with:
           files: src/secureSignalUid2.ts
       - name: Check for change to src/secureSignalEuid.ts
         id: verify_euid
-        uses: tj-actions/changed-files@v41
+        uses: tj-actions/changed-files@716b1e13042866565e00e85fd4ec490e186c4a2f # v41
         with:
           files: src/secureSignalEuid.ts
 


### PR DESCRIPTION
## Summary
Pin third-party (non-GitHub-owned) action references to full-length commit SHAs to mitigate supply-chain attacks from mutable tags.

Only external actions are pinned in this PR (e.g. `docker/*`, `aws-actions/*`, `softprops/*`, etc.). GitHub-owned actions (`actions/*`) are not included in this change.

## Verification
Each SHA can be verified with:
```
git ls-remote https://github.com/<owner>/<repo> <tag>
```

## Test plan
- [ ] Verify CI passes with pinned refs

🤖 Generated with [Claude Code](https://claude.com/claude-code)