### PR TITLE
UID2-6799 Use 'ci-auto-merge' environment

### DIFF
--- a/.github/workflows/build-sdk-package.yml
+++ b/.github/workflows/build-sdk-package.yml
@@ -16,9 +16,10 @@ on:
 
 jobs:
   incrementVersionNumber:
-    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-increase-version-number.yaml@v2
+    uses: IABTechLab/uid2-shared-actions/.github/workflows/shared-increase-version-number.yaml@v3
     with:
       release_type: ${{ inputs.release_type }}
+      merge_environment: ${{ github.ref_protected && 'ci-auto-merge' || '' }}
     secrets: inherit
 
   build:


### PR DESCRIPTION
## Summary
Pass `merge_environment: 'ci-auto-merge'` on protected branches so the release workflow uses the UID2SourceAdmin PAT to bypass the PR review ruleset when auto-merging the version bump PR.

Also bumps `shared-increase-version-number@v2` → `@v3` so the new `merge_environment` input is available.