### PR TITLE
chore: upgrade GitHub Actions from Node 20 to Node 24

### DIFF
--- a/.github/actions/cdn_deployment_aws/action.yaml
+++ b/.github/actions/cdn_deployment_aws/action.yaml
@@ -24,7 +24,7 @@ runs:
 
   steps:
     - name: Configure AWS credentials
-      uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+      uses: aws-actions/configure-aws-credentials@e7f100cf4c008499ea8adda475de1042d6975c7b # v6.2.0
       with:
         aws-region: us-east-2
         role-to-assume: arn:aws:iam::${{ inputs.aws_account_id }}:role/github-runner-for-cdn
@@ -33,7 +33,7 @@ runs:
       shell: bash
       run: aws sts get-caller-identity
 
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifact }}
         path: ./download

--- a/.github/workflows/build-sdk-package.yml
+++ b/.github/workflows/build-sdk-package.yml
@@ -30,11 +30,11 @@ jobs:
         node-version: [20.x]
         target: [development, production]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           ref: ${{ needs.incrementVersionNumber.outputs.git_tag_or_hash }}
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
       - name: Get Package Version
@@ -51,14 +51,14 @@ jobs:
 
       # Upload SDK artifacts for CDN
       - name: Upload UID2 SDK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: uid2SDK-${{ matrix.target }}-${{ steps.version.outputs.package_version }}
           path: ./dist/uid2-sdk-${{ steps.version.outputs.package_version }}.js
           retention-days: 30
 
       - name: Upload EUID SDK artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: euidSDK-${{ matrix.target }}-${{ steps.version.outputs.package_version }}
           path: ./dist/euid-sdk-${{ steps.version.outputs.package_version }}.js
@@ -67,7 +67,7 @@ jobs:
       # Upload NPM package artifacts
       - name: Upload UID2 NPM package
         if: matrix.target == 'production'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: uid2-npm-package-${{ steps.version.outputs.package_version }}
           path: ./dist/uid2-npm/
@@ -75,7 +75,7 @@ jobs:
 
       - name: Upload EUID NPM package
         if: matrix.target == 'production'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: euid-npm-package-${{ steps.version.outputs.package_version }}
           path: ./dist/euid-npm/
@@ -92,7 +92,7 @@ jobs:
     steps:
       - name: Build Changelog
         id: github_release_changelog
-        uses: mikepenz/release-changelog-builder-action@32e3c96f29a6532607f638797455e9e98cfc703d # v4
+        uses: mikepenz/release-changelog-builder-action@348e88fab4c37338b1e803ceb2d4a7a5db6c0833 # v6.2.2
         with:
           toTag: v${{ needs.incrementVersionNumber.outputs.new_version }}
           configurationJson: |
@@ -100,7 +100,7 @@ jobs:
               "pr_template": " - #{{TITLE}} - ( PR: ##{{NUMBER}} )"
             }
       - name: Create Release Notes
-        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           name: v${{ needs.incrementVersionNumber.outputs.new_version }}
           body: ${{ steps.github_release_changelog.outputs.changelog }}

--- a/.github/workflows/build-secure-signal.yml
+++ b/.github/workflows/build-secure-signal.yml
@@ -14,15 +14,15 @@ jobs:
       uid2_modified: ${{ steps.verify_uid2.outputs.any_modified }}
       euid_modified: ${{ steps.verify_euid.outputs.any_modified }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Check for change to src/secureSignalUid2.ts
         id: verify_uid2
-        uses: tj-actions/changed-files@716b1e13042866565e00e85fd4ec490e186c4a2f # v41
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: src/secureSignalUid2.ts
       - name: Check for change to src/secureSignalEuid.ts
         id: verify_euid
-        uses: tj-actions/changed-files@716b1e13042866565e00e85fd4ec490e186c4a2f # v41
+        uses: tj-actions/changed-files@9426d40962ed5378910ee2e21d5f8c6fcbf2dd96 # v47.0.6
         with:
           files: src/secureSignalEuid.ts
 
@@ -35,9 +35,9 @@ jobs:
         target: [development, production]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'
@@ -49,7 +49,7 @@ jobs:
 
       # Upload UID2 Secure Signals Files
       - name: Upload UID2 Secure Signals Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.target }}Uid2SecureSignalScript
           path: ./dist/uid2SecureSignal.js
@@ -57,7 +57,7 @@ jobs:
 
       # Upload EUID Secure Signals Files
       - name: Upload EUID Secure Signals Files
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.target }}EuidSecureSignalScript
           path: ./dist/euidSecureSignal.js

--- a/.github/workflows/node.js.yaml
+++ b/.github/workflows/node.js.yaml
@@ -18,9 +18,9 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: ${{ matrix.node-version }}
           cache: 'npm'


### PR DESCRIPTION
Node 20 is being deprecated on GitHub Actions runners. Starting **June 16, 2026**, runners will use Node 24 by default.

This PR upgrades outdated action references in this repo to the latest released version that ships Node 24 support, pinned to its commit SHA. Each action's node version is determined by reading its `action.yml` at the pinned ref.

See: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
