### PR TITLE
UID2-7307: fix form-data CVE-2026-12143 (HIGH) — upgrade to >=4.0.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5614,15 +5614,15 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -6020,9 +6020,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "dependencies": {
         "function-bind": "^1.1.2"
       },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "path-to-regexp": "^8.4.0"
   },
   "overrides": {
-    "form-data": "^4.0.4",
+    "form-data": ">=4.0.6",
     "qs": "6.14.1",
     "serialize-javascript": "^7.0.3"
   },


### PR DESCRIPTION
## Summary

Fixes CVE-2026-12143 (HIGH): form-data multipart library vulnerability. Updates the npm override from `^4.0.4` to `>=4.0.6` so all transitive consumers resolve to the patched `4.0.6` release.

- **CVE**: [CVE-2026-12143](https://nvd.nist.gov/vuln/detail/CVE-2026-12143) — HIGH severity
- **Package**: form-data, affected: 4.0.4, fixed in: 4.0.6
- **Jira**: [UID2-7307](https://thetradedesk.atlassian.net/browse/UID2-7307)

## Test plan
- [ ] CI vulnerability scan passes (Trivy should no longer report CVE-2026-12143)
- [ ] Build and tests pass